### PR TITLE
Added functionality to open openHAB Preview on macOS based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,36 @@ The extension is designed with openHAB 2.x in mind - most snippets and design pa
 
 ## Configuration
 
-You don't need to provide any configuration to this extension. 
-It automatically detects the hostname of openHAB. Detection is based on the path of active file.
+You are able to configure the hostname and port for the Sitemap preview.
+
+* openhab.host (mandatory), default: openhabianpi
+* openhab.port (optional), default: 8080
+
+These settings should work fine on Windows machines and openHAB installations using the recommended [openHABian](http://docs.openhab.org/installation/openhabian.html) setup.
+They should be edited if you use macOS or *NIX systems or manual openHAB installations.
+
+To edit these settings, simply add overrides to either your user settings or your workspace settings in your Visual Studio Codes preferences.
+
+For further informations on how to change your settings, visit the official [Visual Studio Code docs](https://code.visualstudio.com/docs/getstarted/settings).
+
+### Configuration example (local)
+
+````
+{
+	"openhab.host": "localhost"
+	"openhab.port": "80"	
+}
+````
+
+### Configuration example (macOS)
+
+````
+{
+	"openhab.host": "openhabianpi.local"
+	"openhab.port": "8080"	
+}
+````
+
 
 ## Sitemap preview with Basic UI
 

--- a/package.json
+++ b/package.json
@@ -27,60 +27,81 @@
     "contributes": {
         "menus": {
             "editor/title": [{
-                "when": "resourceLangId == openhab",
-                "command": "openhab.basicUI",
-                "group": "navigation"
-            }]
+                    "when": "resourceLangId == openhab",
+                    "command": "openhab.basicUI",
+                    "group": "navigation"
+                }]
         },
         "keybindings": [{
-            "when": "resourceLangId == openhab",
-            "command": "openhab.basicUI",
-            "key": "ctrl+alt+o",
-            "mac": "cmd+alt+o"
-        }, {
-            "when": "resourceLangId == openhab",
-            "command": "openhab.searchDocs",
-            "key": "shift+alt+o"
-        }],
+                "when": "resourceLangId == openhab",
+                "command": "openhab.basicUI",
+                "key": "ctrl+alt+o",
+                "mac": "cmd+alt+o"
+            }, {
+                "when": "resourceLangId == openhab",
+                "command": "openhab.searchDocs",
+                "key": "shift+alt+o"
+            }],
         "commands": [{
-            "command": "openhab.searchDocs",
-            "title": "openHAB: Search in Docs"
-        }, {
-            "command": "openhab.searchCommunity",
-            "title": "openHAB: Search in Community Forum"
-        }, {
-            "command": "openhab.basicUI",
-            "title": "openHAB: Open Basic UI",
-            "icon": {
-                "light": "./images/oh_color.svg",
-                "dark": "./images/oh.svg"
+                "command": "openhab.searchDocs",
+                "title": "openHAB: Search in Docs"
+            }, {
+                "command": "openhab.searchCommunity",
+                "title": "openHAB: Search in Community Forum"
+            }, {
+                "command": "openhab.basicUI",
+                "title": "openHAB: Open Basic UI",
+                "icon": {
+                    "light": "./images/oh_color.svg",
+                    "dark": "./images/oh.svg"
+                }
+            }],
+        "configuration": {
+            "type": "object",
+            "title": "openHAB Configuration",
+            "properties": {
+                "openhab.host": {
+                    "type": [
+                        "string"
+                    ],
+                    "default": "openhabianpi",
+                    "description": "Specifies the URL for the openHAB preview. (Use 'localhost' when developing locally)"
+                },
+                "openhab.port": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": "8080",
+                    "description": "Specifies the port for the openHAB preview."
+                }
             }
-        }],
+        },
         "languages": [{
-            "id": "openhab",
-            "aliases": ["openHAB"],
-            "extensions": [
-                ".rules",
-                ".script",
-                ".items",
-                ".sitemap",
-                ".things",
-                ".persist"
-            ],
-            "configuration": "./language-configuration.json"
-        }],
+                "id": "openhab",
+                "aliases": ["openHAB"],
+                "extensions": [
+                    ".rules",
+                    ".script",
+                    ".items",
+                    ".sitemap",
+                    ".things",
+                    ".persist"
+                ],
+                "configuration": "./language-configuration.json"
+            }],
         "grammars": [{
-            "language": "openhab",
-            "scopeName": "source.openhab",
-            "path": "./syntaxes/openhab.tmLanguage.json"
-        }],
+                "language": "openhab",
+                "scopeName": "source.openhab",
+                "path": "./syntaxes/openhab.tmLanguage.json"
+            }],
         "snippets": [{
-            "language": "openhab",
-            "path": "./snippets/openhabrules.json"
-        }, {
-            "language": "openhab",
-            "path": "./snippets/openhab.json"
-        }]
+                "language": "openhab",
+                "path": "./snippets/openhabrules.json"
+            }, {
+                "language": "openhab",
+                "path": "./snippets/openhab.json"
+            }]
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,8 @@ import _ = require('lodash')
 async function init(context: ExtensionContext, disposables: Disposable[]): Promise<void> {
     let ui = new OpenHABContentProvider()
     let registration = workspace.registerTextDocumentContentProvider(SCHEME, ui)
+    
+    const path = require('path');
 
     const openHtml = (uri: Uri, title) => {
         return commands.executeCommand('vscode.previewHtml', uri, ViewColumn.Two, title)
@@ -49,6 +51,7 @@ async function init(context: ExtensionContext, disposables: Disposable[]): Promi
         openHtml(encodeOpenHABUri(query), title)
 
     let basicUI = commands.registerCommand('openhab.basicUI', () => {
+        let config = workspace.getConfiguration('openhab')
         let editor = window.activeTextEditor
         if (!editor) {
             window.showInformationMessage('No editor is active')
@@ -56,10 +59,8 @@ async function init(context: ExtensionContext, disposables: Disposable[]): Promi
         }
 
         let absolutePath = editor.document.fileName
-        let filePath = absolutePath.split('\\')
-        let fileName = filePath.pop()
-        let hostname = absolutePath.slice(0,2) === '\\\\' ? _.compact(filePath)[0] : 'localhost'
-        let address = hostname + ':8080'
+        let fileName = path.basename(absolutePath)
+        let address = config.port ? config.host + ':' + config.port : config.host
 
         let params = {
             hostname: address

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
         "lib": [
             "es6"
         ],
+        "types":[
+            "node"
+        ],
         "sourceMap": true,
         "rootDir": "."
     },


### PR DESCRIPTION
Unfortunately I'm not able to test on Linux atm.
Since there seems to be no "configurability" in VSCode extensions a lot has to be hardcoded. :disappointed:

Closes #15