### PR TITLE
Updated README.md, host configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ You are able to configure the hostname and port for the Sitemap preview.
 * openhab.host (mandatory), default: openhabianpi
 * openhab.port (optional), default: 8080
 
+*openhab.host* will also work with the ip-adress of your openHAB instance, instead of the hostname.
+
 These settings should work fine on Windows machines and openHAB installations using the recommended [openHABian](http://docs.openhab.org/installation/openhabian.html) setup.
 They should be edited if you use macOS or *NIX systems or manual openHAB installations.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You are able to configure the hostname and port for the Sitemap preview.
 * openhab.host (mandatory), default: openhabianpi
 * openhab.port (optional), default: 8080
 
-*openhab.host* will also work with the ip-adress of your openHAB instance, instead of the hostname.
+*openhab.host* will also work with the IP address of your openHAB instance, instead of the hostname.
 
 These settings should work fine on Windows machines and openHAB installations using the recommended [openHABian](http://docs.openhab.org/installation/openhabian.html) setup.
 They should be edited if you use macOS or *NIX systems or manual openHAB installations.

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
                         "string"
                     ],
                     "default": "openhabianpi",
-                    "description": "Specifies the URL for the openHAB preview. (Use 'localhost' when developing locally)"
+                    "description": "Specifies the URL or IP adress for the openHAB preview. (Use 'localhost' when developing locally)"
                 },
                 "openhab.port": {
                     "type": [


### PR DESCRIPTION
Added a note to the configuration section, to clarify that the settings will take a hostname or the ip adress of the openHAB instance.
Suggested here: <https://community.openhab.org/t/visual-studio-code-openhab-extension/30205/56?u=confectrician>

Signed-off-by:  Jerome Luckenbach <github@luckenba.ch> (github: @Confectrician)