### PR TITLE
Fix wrongful italic presentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You are able to configure the hostname and port for the Sitemap preview.
 *openhab.host* will also work with the IP address of your openHAB instance, instead of the hostname.
 
 These settings should work fine on Windows machines and openHAB installations using the recommended [openHABian](http://docs.openhab.org/installation/openhabian.html) setup.
-They should be edited if you use macOS or *NIX systems or manual openHAB installations.
+They should be edited if you use macOS or &ast;NIX systems or manual openHAB installations.
 
 To edit these settings, simply add overrides to either your user settings or your workspace settings in your Visual Studio Codes preferences.
 


### PR DESCRIPTION
GitHub would show half the file as italic because there is no second asterisk to end the format block.

Signed-off-by: Thomas Dietrich <thomas.dietrich@tu-ilmenau.de> (github: ThomDietrich)