### PR TITLE
Added 'Open Karaf console' feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "activationEvents": [
         "onCommand:openhab.searchDocs",
         "onCommand:openhab.searchCommunity",
+        "onCommand:openhab.openKaraf",
         "onCommand:openhab.basicUI",
         "onCommand:openhab.command.refreshEntry",
         "onCommand:openhab.command.showInPaperUI",
@@ -119,6 +120,10 @@
             {
                 "command": "openhab.searchCommunity",
                 "title": "openHAB: Search in Community Forum"
+            },
+            {
+                "command": "openhab.openKaraf",
+                "title": "openHAB: Open Karaf console"
             },
             {
                 "command": "openhab.command.showInPaperUI",
@@ -235,6 +240,13 @@
                     ],
                     "default": "paperui",
                     "description": "(optional) If you're using openHAB2 build from before 9th Jan 2017, change this parameter to 'ui'"
+                },
+                "openhab.karafCommand": {
+                    "type": [
+                        "string"
+                    ],
+                    "default": "ssh openhab@%openhabhost% -p 8101",
+                    "description": "Directly log into openHAB Karaf console. Note that this option is available only if you exposed Karaf console."
                 },
                 "openhab.sitemapPreviewUI": {
                     "type": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,10 +86,16 @@ async function init(context: ExtensionContext, disposables: Disposable[]): Promi
         openBrowser(`https://community.openhab.org/search?q=${query}`)
     }))
 
+    disposables.push(commands.registerCommand('openhab.openKaraf', () => {
+        let command = config.karafCommand.replace(/%openhabhost%/g, config.host)
+        const terminal = window.createTerminal('openHAB')
+        terminal.sendText(command, true)
+        terminal.show(false)
+    }))
+
     disposables.push(commands.registerCommand('openhab.command.showInPaperUI', (query?) => {
         let param: string = query.name ? query.name : query
         let title = `${param} - Paper UI`
-        let config = workspace.getConfiguration('openhab')
         let paperPath = config.paperPath
         let route = `/${paperPath}/index.html%23/configuration/`
 


### PR DESCRIPTION
This was a feature request from Peder Schmedling on Twitter - https://twitter.com/Leif_/status/931479506824544256

The PR *might be* a little bit related to #9.
It introduces a new configuration setting - `openhab.karafCommand`.

By default its value is `ssh openhab@%openhabhost% -p 8101`
`%openhabhost%` is effectively replaced with the `openhab.host` value.

Pressing `Ctrl + Shift + P` and choosing "openHAB: Open Karaf console" the command will execute in a new Terminal window (default one) integrated with VSCode.

In my personal setup my default terminal is Git Bash:
```
"terminal.integrated.shell.windows": "C:\\Program Files\\Git\\bin\\bash.exe",
```

![karaf](https://user-images.githubusercontent.com/2270505/32993652-8343bed6-cd5b-11e7-9c8f-b9efd85bcca1.gif)

Note that you need to:

* have `ssh` installed on your environment
* have Karaf exposed to the external interface

This feature allows you to modify the new param and e.g. show the openHAB logs immediately:

```
    "openhab.karafCommand": "ssh openhab@%openhabhost% -p 8101 -t 'log:tail'",
```

Signed-off-by: Kuba Wolanin <hi@kubawolanin.com>