### PR TITLE
Open Sitemap directly

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,21 +69,23 @@ async function init(context: ExtensionContext, disposables: Disposable[], config
         }
 
         // If there is only one user created sitemap open it directly
-        getSitemaps().then((sitemaps)=>{
+        getSitemaps().then(sitemaps => {
+            const defaultName = sitemap => sitemap.name === '_default'
+            const defaultSitemap = sitemaps.find(defaultName)
 
-            if(sitemaps.length == 1){
+            if (sitemaps.length === 1) {
                 return openUI({
                     route: `/${ui}/app?sitemap=${sitemaps[0].name}`,
                 }, sitemaps[0].name)
             }
 
-            if(sitemaps.length == 2 && typeof(sitemaps.find(sitemap => sitemap.name === '_default')) !== 'undefined'){
-                let wantedIndex = (sitemaps.indexOf(sitemap => sitemap.name === '_default') == 0) ? 1 : 0
+            if (sitemaps.length === 2 && typeof defaultSitemap !== 'undefined') {
+                const index = sitemaps.indexOf(defaultName) === 0 ? 1 : 0
                 return openUI({
-                    route: `/${ui}/app?sitemap=${sitemaps[wantedIndex].name}`,
-                }, sitemaps[wantedIndex].name)
+                    route: `/${ui}/app?sitemap=${sitemaps[index].name}`,
+                }, sitemaps[index].name)
             }
-            
+
             return openUI()
         });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import {
 import {
     openBrowser,
     openHtml,
+    getSitemaps,
     openUI
 } from './Utils'
 
@@ -67,7 +68,25 @@ async function init(context: ExtensionContext, disposables: Disposable[], config
             }, 'Classic UI')
         }
 
-        return openUI()
+        // If there is only one user created sitemap open it directly
+        getSitemaps().then((sitemaps)=>{
+
+            if(sitemaps.length == 1){
+                return openUI({
+                    route: `/${ui}/app?sitemap=${sitemaps[0].name}`,
+                }, sitemaps[0].name)
+            }
+
+            if(sitemaps.length == 2 && typeof(sitemaps.find(sitemap => sitemap.name === '_default')) !== 'undefined'){
+                let wantedIndex = (sitemaps.indexOf(sitemap => sitemap.name === '_default') == 0) ? 1 : 0
+                return openUI({
+                    route: `/${ui}/app?sitemap=${sitemaps[wantedIndex].name}`,
+                }, sitemaps[wantedIndex].name)
+            }
+            
+            return openUI()
+        });
+
     }))
 
     disposables.push(commands.registerCommand('openhab.searchDocs', () => openBrowser()))


### PR DESCRIPTION
Closes #38

As mentioned in the issue, i don't count the `_default` sitemap as valid for this logic 
and added a special exclusion for it.
If someone has a different opinion feel free to share and discuss it here. 🙂 

It works fine on my system.

Signed-off-by: Jerome Luckenbach <github@luckenba.ch>