### PR TITLE
added configuration option for Item name casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - removed settings param 'restCompletions'
 - renamed settings param 'lspEnabled' to 'remoteLspEnabled'
 - renamed settings param 'lspPort' to 'remoteLspPort'
+- added settings param 'itemCasing' to allow for Item format configuration (#133)
+- removed reference to library 'underscore.string' (#133)
 
 ## 0.4.1 - 2018-12-09
 - Fixed Basic UI Preview (#117)

--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,6 @@
         "lodash": "^4.17.4",
         "request": "^2.83.0",
         "request-promise-native": "^1.0.5",
-        "underscore.string": "^3.3.5",
         "vscode": "^1.1.26",
         "vscode-languageclient": "^5.2.1"
     }

--- a/client/src/Utils.ts
+++ b/client/src/Utils.ts
@@ -10,6 +10,26 @@ import {PreviewPanel} from './WebView/PreviewPanel'
 import * as _ from 'lodash'
 import * as request from 'request-promise-native'
 
+/**
+ * humanize function adapter from the previously included underscore.string library
+ */
+export function humanize(str: string) : string {
+    return _.upperFirst(
+        // original 'underscored' of underscore.string
+        str.trim()
+        .replace(/([a-z\d])([A-Z]+)/g, '$1_$2')
+        .replace(/[-\s]+/g, '_')
+        .toLowerCase()
+        .replace(/([a-z\d])([A-Z]+)/g, '$1_$2')
+        .replace(/_id$/, '')
+        .replace(/_/g, ' ')
+        // original 'humanize' of underscore.string
+        .replace(/_id$/, '')
+        .replace(/_/g, ' ')
+        .trim()
+    );
+}
+
 export function getHost() {
     let config = workspace.getConfiguration('openhab')
     let host = config.host

--- a/package.json
+++ b/package.json
@@ -237,6 +237,15 @@
                     ],
                     "default": "basicui",
                     "description": "(optional) Choose between `basicui` and `classicui` for the sitemap preview panel"
+                },
+                "openhab.itemCasing": {
+                    "type": "string",
+                    "default": "camel",
+                    "enum": [
+                        "camel",
+                        "snake"
+                    ],
+                    "markdownDescription": "Choose how the `Create Items from Channels` command generates Item names. Use `camel` for `CamelCase` or `snake` for `Upper_Snake_Case`."
                 }
             }
         },


### PR DESCRIPTION
the casing of generated Item names from Thing labels
can now be configured using the extension's configuration.

fixes #132