### PR TITLE
Fix https lsp problems

### DIFF
--- a/client/src/LanguageClient/RemoteLanguageClientProvider.ts
+++ b/client/src/LanguageClient/RemoteLanguageClientProvider.ts
@@ -17,8 +17,9 @@ export class RemoteLanguageClientProvider {
 
     public connect(): Disposable {
         let config = workspace.getConfiguration('openhab')
+        let host = config.host.includes('://') ? config.host.split('://')[1] : config.host
         let connectionInfo = {
-            host: config.host,
+            host: host,
             port: config.remoteLspPort
         }
 


### PR DESCRIPTION
Possible fix for remote lsp in combination with a https enabled reverse proxy.

Test extension can be downloaded here:
[openhab-0.5.1-httpsFix.zip](https://github.com/openhab/openhab-vscode/files/3218458/openhab-0.5.1-httpsFix.zip)

