### PR TITLE
Activation events + JSR223 preparations

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,14 @@
         "onCommand:openhab.command.things.docs",
         "onCommand:openhab.command.things.copyUID",
         "onCommand:openhab.command.things.addItems",
-        "onLanguage:openhab"
+        "onLanguage:openhab",
+        "workspaceContains:items/*.items",
+        "workspaceContains:sitemaps/*.sitemap",
+        "workspaceContains:things/*.things",
+        "workspaceContains:rules/*.rules",
+        "workspaceContains:transform/*.map",
+        "workspaceContains:transform/*.js",
+        "workspaceContains:automation/jsr223/*"
     ],
     "main": "./client/out/extension",
     "contributes": {


### PR DESCRIPTION
This adds some more activation events.

The extension will then startop if there are typical openHAB folders and files present.
I have also added the automation folder to have items-completion when working with jsr223 scripts.

Closes #140 

Signed-off-by: Jerome Luckenbach <github@luckenba.ch>