### PR TITLE
Add info/warning for remote LSP usage to settings dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
                         "boolean"
                     ],
                     "default": true,
-                    "description": "Enables communication with Language Server of openHAB instance."
+                    "description": "Enables communication with Language Server of openHAB instance.\nIf you are facing connection problems make sure to connect your config folder through a dedicated network drive."
                 },
                 "openhab.username": {
                     "type": [


### PR DESCRIPTION
Add info/warning for the remote LSP setting to use mounted network share.

Signed-off-by: Jerome Luckenbach <github@luckenba.ch>