### PR TITLE
Fix case insensitivity in openHAB language. Fixes #17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix https lsp problems (#139)
+- Fix case insensivity bug (#170)
 
 ## [0.6.0] - tba
 

--- a/meta/openhab.tmLanguage.json
+++ b/meta/openhab.tmLanguage.json
@@ -549,7 +549,7 @@
                             "name": "keyword.operator.dereference.openhab"
                         }
                     },
-                    "match": "\\b(?:[a-z]\\w*(\\.))*[A-Z]+\\w*\\b",
+                    "match": "(?<=\\s|\\=|\\()\\b[a-zA-Z]+\\w*\\b(?=\\s|\\.|\\))",
                     "name": "entity.name.type.class.openhab"
                 },
                 {

--- a/meta/openhab.tmLanguage.json
+++ b/meta/openhab.tmLanguage.json
@@ -549,7 +549,7 @@
                             "name": "keyword.operator.dereference.openhab"
                         }
                     },
-                    "match": "(?<=\\s|\\=|\\()\\b[a-zA-Z]+\\w*\\b(?=\\s|\\.|\\))",
+                    "match": "(?<=\\s|\\=|\\(|\\,|\\[)\\b[a-zA-Z]+\\w*\\b(?=\\s|\\.|\\)|\\,|\\={2})",
                     "name": "entity.name.type.class.openhab"
                 },
                 {


### PR DESCRIPTION
This one will fix #17 

It will improve the syntax highlighting of items over severel openHAB related file types.

## Side effect
It will also highlight some none item words in `.persist ` and `.things`.
A full solution of this would possibly need some bigger adaptions in the tmlanguage file.
This could be combined with a refactoring for #128 
For now it will still be an improvement.

If possible we could think about splitting up the language files into parts,
to handle things and persist different from items/rules/sitemaps.
This would make sense, since things and persist files have a completely different syntax compared to the other file types.

Maybe i can find a even better matching expression in the future, but for now i see mor benefits than flaws.