### PR TITLE
Added copy and doc to item commands.

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,11 @@
             },
             {
                 "command": "openhab.command.things.addItems",
-                "title": "Create Items from Channels"
+                "title": "Create Items from Channels",
+                "icon": {
+                    "light": "resources/light/arrow_right.svg",
+                    "dark": "resources/dark/arrow_right.svg"
+                  }
             },
             {
                 "command": "openhab.command.things.copyUID",
@@ -89,7 +93,11 @@
             },
             {
                 "command": "openhab.command.things.docs",
-                "title": "Binding documentation"
+                "title": "Binding documentation",
+                "icon": {
+                    "light": "resources/light/http.svg",
+                    "dark": "resources/dark/http.svg"
+                  }
             },
             {
                 "command": "openhab.openConsole",
@@ -266,12 +274,22 @@
                     "when": "view == openhabThings"
                 },
                 {
+                    "command": "openhab.command.things.addItems",
+                    "when": "view == openhabThings",
+                    "group": "inline"
+                },
+                {
                     "command": "openhab.command.things.copyUID",
                     "when": "view == openhabThings"
                 },
                 {
                     "command": "openhab.command.things.docs",
                     "when": "view == openhabThings && viewItem == thing"
+                },
+                {
+                    "command": "openhab.command.things.docs",
+                    "when": "view == openhabThings && viewItem == thing",
+                    "group": "inline"
                 }
             ],
             "view/title": [

--- a/resources/dark/arrow_right.svg
+++ b/resources/dark/arrow_right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0z"/><path fill="#ffffff" d="M16.01 11H4v2h12.01v3L20 12l-3.99-4z"/></svg>

--- a/resources/dark/http.svg
+++ b/resources/dark/http.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="#ffffff" d="M4.5 11h-2V9H1v6h1.5v-2.5h2V15H6V9H4.5v2zm2.5-.5h1.5V15H10v-4.5h1.5V9H7v1.5zm5.5 0H14V15h1.5v-4.5H17V9h-4.5v1.5zm9-1.5H18v6h1.5v-2h2c.8 0 1.5-.7 1.5-1.5v-1c0-.8-.7-1.5-1.5-1.5zm0 2.5h-2v-1h2v1z"/><path fill="none" d="M24 24H0V0h24v24z"/></svg>

--- a/resources/light/arrow_right.svg
+++ b/resources/light/arrow_right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0z"/><path d="M16.01 11H4v2h12.01v3L20 12l-3.99-4z"/></svg>

--- a/resources/light/http.svg
+++ b/resources/light/http.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M4.5 11h-2V9H1v6h1.5v-2.5h2V15H6V9H4.5v2zm2.5-.5h1.5V15H10v-4.5h1.5V9H7v1.5zm5.5 0H14V15h1.5v-4.5H17V9h-4.5v1.5zm9-1.5H18v6h1.5v-2h2c.8 0 1.5-.7 1.5-1.5v-1c0-.8-.7-1.5-1.5-1.5zm0 2.5h-2v-1h2v1z"/><path fill="none" d="M24 24H0V0h24v24z"/></svg>


### PR DESCRIPTION
This will add two commands, that are currently available from context menu only,
to the things explorer as direct accessible commands.

![image](https://user-images.githubusercontent.com/7161177/68614214-c72bf480-04c0-11ea-829f-0d42fc589405.png)

