### PR TITLE
Extract HoverProvider as own class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.0] - 2019-11-tba
 
 ### Added
-- Add hover provider with rest api integration (#146)
+- Add hover provider with rest api integration (#146, #178)
 - Add/Move to an azure build pipeline environment (#148, #150, #166)
 - Add support for webpack (#155)
 - Added output channel for better user interaction (#156)
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clean Readme and introduce docs folder (#149)
 - Refactor language config files (#154)
 - Make TreeView visible when `restApi` is available to benefit from it in `JSR223` developing (#154)
+- Made some commands directly accessible in things explorer (#177)
 
 ### Fixed
 - Fix https lsp problems (#139)

--- a/client/src/HoverProvider/HoverProvider.ts
+++ b/client/src/HoverProvider/HoverProvider.ts
@@ -1,0 +1,116 @@
+import { Hover } from 'vscode'
+import { MarkdownString } from 'vscode'
+
+import * as utils from '../Utils'
+import * as request from 'request-promise-native'
+
+/**
+ * Handles hover actions in editor windows.
+ * Provides additional information for existing items through rest api.
+ *
+ * @author Jerome Luckenbach - Initial contribution
+ */
+export class HoverProvider {
+
+    /**
+     * Only allow a single provider to exist at a time.
+     */
+    private static _currentProvider: HoverProvider | undefined
+
+    /**
+     *
+     */
+    private  knownItems:String[]
+
+    /**
+     *
+     */
+    private  lastItemsUpdate : Number;
+
+    /**
+     * Only allow the class to call the constructor
+     */
+    public constructor(){
+        this.updateItems()
+    }
+
+    /**
+     * Checks hovered editor area for existing openHAB Items and provides some live data from rest api if aan item name is found.
+     *
+     * @param hoveredText The currently hovered text part
+     * @returns A thenable [Hover](Hover) object with live information or null if no item is found
+     */
+    public getRestHover(hoveredText) : Thenable<Hover>|null {
+        console.log(`Checking if => ${hoveredText} <= is a knownItem now`)
+        if(this.knownItems.includes(hoveredText)){
+            return new Promise((resolve, reject) => {
+                console.log(`Requesting => ${utils.getHost()}/rest/items/${hoveredText} <= now`)
+
+                request(`${utils.getHost()}/rest/items/${hoveredText}`)
+                    .then((response) => {
+                        let result = JSON.parse(response)
+
+                        if(!result.error) {
+                            let resultText = new MarkdownString()
+
+                            // Show Member Information for Group Items too
+                            if(result.type === "Group"){
+                                resultText.appendCodeblock(`Item ${result.name} | ${result.state}`, 'openhab')
+                                resultText.appendMarkdown(`##### Members:`)
+
+                                result.members.forEach( (member, key, result) => {
+                                    resultText.appendCodeblock(`Item ${member.name} | ${member.state}`, 'openhab')
+
+                                    // No newline after the last member information
+                                    if(!Object.is(result.length - 1, key)){
+                                        resultText.appendText(`\n`)
+                                    }
+                                });
+                            }
+                            else{
+                                resultText.appendCodeblock(`${result.state}`, 'openhab');
+                            }
+
+                            resolve(new Hover(resultText))
+                        }
+                    })
+                    .catch(() => reject(false))
+            });
+        }
+        else {
+            console.log(`That's no openHAB item. Waiting for the next hover.`)
+            return null
+        }
+    }
+
+    /**
+     * Update known Items array and store the last time it has been updated.
+     */
+    private updateItems() : Boolean {
+
+        request(`${utils.getHost()}/rest/items/`)
+            .then((response) => {
+                // Clear prossible existing array
+                this.knownItems = new Array<String>()
+
+                let result = JSON.parse(response)
+
+                result.forEach(item => {
+                    this.knownItems.push(item.name)
+                });
+
+                this.lastItemsUpdate = Date.now()
+
+                return true
+            })
+            .catch((error) => {
+                console.log(`Failed to update Items for HoverProvider`)
+                console.log(error)
+
+                utils.appendToOutput(`Could not reload items for HoverProvider`)
+
+                return false
+            });
+        return false
+    }
+}

--- a/client/src/Utils.ts
+++ b/client/src/Utils.ts
@@ -18,7 +18,7 @@ let extensionOutput: OutputChannel = null
 
 /**
  * Humanize function adapter from the previously included underscore.string library
- * 
+ *
  * @param str The string to convert
  */
 export function humanize(str: string) : string {
@@ -64,64 +64,7 @@ export function getHost() {
 }
 
 /**
- * Checks hovered editor area for existing openHAB Items and provides some live data from rest api if aan item name is found.
- * 
- * @param hoveredText The currently hovered text part
- * @returns A thenable [Hover](Hover) object with live information or null if no item is found
- */
-export function getRestHover(hoveredText) : Thenable<Hover>|null {
-    return new Promise((resolve, reject) => {
-
-        console.log(`Requesting => ${getHost()}/rest/items/${hoveredText} <= now`)
-
-        request(`${getHost()}/rest/items/${hoveredText}`)
-            .then((response) => {
-
-                let result = JSON.parse(response)
-        
-                if(!result.error) {
-
-                    let resultText = new MarkdownString()
-
-                    if(result.type === "Group"){
-
-                        resultText.appendCodeblock(`Item ${result.name} | ${result.state}`, 'openhab');
-                        resultText.appendMarkdown(`##### Members:`)
-
-                        result.members.forEach( (member, key, result) => {
-
-                            resultText.appendCodeblock(`Item ${member.name} | ${member.state}`, 'openhab')
-
-                            // No newline after the last member information
-                            if(!Object.is(result.length - 1, key)){
-                                resultText.appendText(`\n`)
-                            }
-
-                        });
-
-                    }
-                    else{
-
-                        resultText.appendCodeblock(`${result.state}`, 'openhab');
-                        
-                    }
-
-                    resolve(new Hover(resultText))
-
-                }
-                else {
-
-                    console.log(`That's no openHAB item. Waiting for the next hover.`)
-                    resolve(null)
-
-                }
-            })
-            .catch(() => reject(false))
-    }) 
-}
-
-/**
- * Returns the current simple mode status retreived via rest api 
+ * Returns the current simple mode status retreived via rest api
  */
 export function getSimpleModeState(): Thenable<Boolean> {
     return new Promise((resolve, reject) => {
@@ -147,7 +90,7 @@ export function getSitemaps(): Thenable<any[]> {
 
 /**
  * Opens an external browser with the given url.
- * 
+ *
  * @param url The url to navigate to
  */
 export function openBrowser(url) {
@@ -166,7 +109,7 @@ export function openBrowser(url) {
 
 /**
  * Opens a vscode Webview panel aside, with the given data.
- * 
+ *
  * @param extensionPath The path of this extension
  * @param query The query to append. Defaults to the basic ui node.
  * @param title The title, that will be shown for the UI tab.
@@ -178,13 +121,13 @@ export function openUI(extensionPath: string, query: string = "/basicui/app", ti
     PreviewPanel.createOrShow(
         extensionPath,
         (title !== undefined) ? title : undefined,
-        srcPath 
+        srcPath
     );
 }
 
 /**
  * Handle a occuring request error.
- * 
+ *
  * @param err The current error
  */
 export async function handleRequestError(err) {
@@ -208,11 +151,11 @@ export async function handleRequestError(err) {
 /**
  * This will send a message frmo the extension to its output channel.
  * If the channel isn't existing already, it will be created during method run.
- * 
+ *
  * @param message The message to append to the extensions output Channel
  */
 export function appendToOutput(message: string){
-    
+
     if(!extensionOutput) { extensionOutput = window.createOutputChannel("openHAB Extension") }
 
     extensionOutput.appendLine(message)

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -24,13 +24,14 @@ import { RemoteLanguageClientProvider } from './LanguageClient/RemoteLanguageCli
 import { Item } from './ItemsExplorer/Item'
 import { Thing } from './ThingsExplorer/Thing'
 import { Channel } from './ThingsExplorer/Channel'
+import { HoverProvider } from './HoverProvider/HoverProvider';
 
 import * as _ from 'lodash'
 import * as ncp from 'copy-paste'
 import * as path from 'path'
 
-let _extensionPath: string;
-let ohStatusBarItem: StatusBarItem;
+let _extensionPath: string
+let ohStatusBarItem: StatusBarItem
 
 /**
  * Initializes the openHAB extension
@@ -139,6 +140,7 @@ async function init(disposables: Disposable[], config, context): Promise<void> {
         const itemsExplorer = new ItemsExplorer()
         const thingsExplorer = new ThingsExplorer()
         const itemsCompletion = new ItemsCompletion()
+        const ohHoverProvider = new HoverProvider()
 
         disposables.push(window.registerTreeDataProvider('openhabItems', itemsExplorer))
         disposables.push(window.registerTreeDataProvider('openhabThings', thingsExplorer))
@@ -171,6 +173,7 @@ async function init(disposables: Disposable[], config, context): Promise<void> {
         disposables.push(commands.registerCommand('openhab.command.things.copyUID', (query) =>
             ncp.copy(query.UID || query.uid)))
 
+
         disposables.push(languages.registerHoverProvider({ language: 'openhab', scheme: 'file'}, {
 
                 provideHover(document, position, token){
@@ -183,7 +186,8 @@ async function init(disposables: Disposable[], config, context): Promise<void> {
                         return null
                     }
 
-                    return utils.getRestHover(hoveredText)
+                    // Will return null or the hover content
+                    return ohHoverProvider.getRestHover(hoveredText)
                 }
             })
 


### PR DESCRIPTION
- Extracted HoverProvider to an own class.
- Geta all Items from RestApi on startup and compares each hovered text before requesting the item endpoint on openHAB rest api.

![vsCodeHoverClass](https://user-images.githubusercontent.com/7161177/68624744-cfdbf500-04d7-11ea-8ac2-9f7247e2c78a.gif)
