### PR TITLE
Update item cache on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - tba
 ## [0.7.0] - tba
 
+### Changed
+- Added newly used material icons to notice file (#187)
+- HoverProvider: Itemcache is refreshed on save of items files (#189)
+
+### Fixed
+- Fix treeview icons with dynamically generated path (#188)
+
 ## [0.6.0] - 2019-11-13
 
 ### Added

--- a/client/src/HoverProvider/HoverProvider.ts
+++ b/client/src/HoverProvider/HoverProvider.ts
@@ -1,5 +1,7 @@
-import { Hover } from 'vscode'
-import { MarkdownString } from 'vscode'
+import {
+    Hover,
+    MarkdownString
+} from 'vscode'
 
 import * as utils from '../Utils'
 import * as request from 'request-promise-native'
@@ -18,14 +20,9 @@ export class HoverProvider {
     private static _currentProvider: HoverProvider | undefined
 
     /**
-     *
+     * Array of known Items from the openHAB environment
      */
     private  knownItems:String[]
-
-    /**
-     *
-     */
-    private  lastItemsUpdate : Number;
 
     /**
      * Only allow the class to call the constructor
@@ -84,9 +81,9 @@ export class HoverProvider {
     }
 
     /**
-     * Update known Items array and store the last time it has been updated.
+     * Update known Items array
      */
-    private updateItems() : Boolean {
+    public updateItems() : Boolean {
 
         request(`${utils.getHost()}/rest/items/`)
             .then((response) => {
@@ -99,8 +96,7 @@ export class HoverProvider {
                     this.knownItems.push(item.name)
                 });
 
-                this.lastItemsUpdate = Date.now()
-
+                console.log(`Updates Items for HoverProvider`)
                 return true
             })
             .catch((error) => {

--- a/client/src/Utils.ts
+++ b/client/src/Utils.ts
@@ -160,3 +160,12 @@ export function appendToOutput(message: string){
 
     extensionOutput.appendLine(message)
 }
+
+/**
+ * Sleep for some time
+ *
+ * @param sleepTime wanted time in milliseconds
+ */
+export async function sleep(sleepTime: number){
+    return new Promise(resolve => setTimeout(resolve, sleepTime))
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -29,6 +29,7 @@ import { HoverProvider } from './HoverProvider/HoverProvider';
 import * as _ from 'lodash'
 import * as ncp from 'copy-paste'
 import * as path from 'path'
+import { SSL_OP_EPHEMERAL_RSA } from 'constants';
 
 let _extensionPath: string
 let ohStatusBarItem: StatusBarItem
@@ -199,7 +200,11 @@ async function init(disposables: Disposable[], config, context): Promise<void> {
 
             if(fileEnding === "items"){
                 console.log(`Items file was saved.\nRefreshing cached items for HoverProvider`);
-                ohHoverProvider.updateItems();
+
+                // Give item registry some time to reflect the file changes.
+                utils.sleep(1500).then(() => {
+                    ohHoverProvider.updateItems();
+                });
             }
         });
     }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -192,6 +192,16 @@ async function init(disposables: Disposable[], config, context): Promise<void> {
             })
 
         )
+
+        // Listen for document save events, to update the cached items
+        workspace.onDidSaveTextDocument((savedDocument) => {
+            let fileEnding = savedDocument.fileName.split(".").slice(-1)[0]
+
+            if(fileEnding === "items"){
+                console.log(`Items file was saved.\nRefreshing cached items for HoverProvider`);
+                ohHoverProvider.updateItems();
+            }
+        });
     }
 
     if (config.remoteLspEnabled) {


### PR DESCRIPTION
This will listen for saving a document and update the items Cache for HoverProvider,
if the saved document was an item file.

This way newly created items won't get shown as `undefined` until next vscode start anymore.