### PR TITLE
Encode username and password to make a valid URI. Fixes #213

### DIFF
--- a/client/src/Utils.ts
+++ b/client/src/Utils.ts
@@ -46,8 +46,8 @@ export function getHost() {
     let config = workspace.getConfiguration('openhab')
     let host = config.host
     let port = config.port
-    let username = config.username
-    let password = config.password
+    let username = encodeURIComponent(config.username)
+    let password = encodeURIComponent(config.password)
 
     let protocol = 'http'
 


### PR DESCRIPTION
Apparently the error message about the certificate not matching the hostname was a red herring due to my request URI being malformed. In my SUPERSECRET password I had characters that needed to be encoded.