### PR TITLE
Refactor config usage

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outFiles": [ "${workspaceRoot}/**/dist/**/*.js" ],
+            "outFiles": [ "${workspaceRoot}/**/out/**/*.js" ],
             "preLaunchTask": "npm"
         },
         {

--- a/client/src/HoverProvider/HoverProvider.ts
+++ b/client/src/HoverProvider/HoverProvider.ts
@@ -102,6 +102,7 @@ export class HoverProvider {
             .catch((error) => {
                 console.error(`Failed to update Items for HoverProvider`, error)
                 utils.appendToOutput(`Could not reload items for HoverProvider`)
+                utils.handleRequestError(error)
 
                 return false
             })

--- a/client/src/ItemsExplorer/ItemsCompletion.ts
+++ b/client/src/ItemsExplorer/ItemsCompletion.ts
@@ -10,7 +10,6 @@ import {
 
 import { Item } from './Item'
 import { ItemsModel } from './ItemsModel'
-import { getHost } from './../Utils'
 import * as _ from 'lodash'
 
 /**
@@ -23,7 +22,7 @@ export class ItemsCompletion implements CompletionItemProvider {
 
     constructor() {
         if (!this.model) {
-            this.model = new ItemsModel(getHost())
+            this.model = new ItemsModel()
         }
     }
 

--- a/client/src/ItemsExplorer/ItemsExplorer.ts
+++ b/client/src/ItemsExplorer/ItemsExplorer.ts
@@ -9,7 +9,6 @@ import {
 
 import { Item } from './Item'
 import { ItemsModel } from './ItemsModel'
-import { getHost } from './../Utils'
 import * as path from 'path'
 
 /**
@@ -24,11 +23,9 @@ export class ItemsExplorer implements TreeDataProvider<Item> {
     readonly onDidChangeTreeData: Event<any> = this._onDidChangeTreeData.event
 
     constructor() {
-        this.openhabHost = getHost()
         this.extensionpath = extensions.getExtension("openhab.openhab").extensionPath
     }
 
-    private openhabHost: string
     private extensionpath: string
 
     private model: ItemsModel
@@ -76,7 +73,7 @@ export class ItemsExplorer implements TreeDataProvider<Item> {
     public getChildren(item?: Item): Item[] | Thenable<Item[]> {
         if (!item) {
             if (!this.model) {
-                this.model = new ItemsModel(this.openhabHost)
+                this.model = new ItemsModel()
             }
 
             return this.model.roots

--- a/client/src/ItemsExplorer/ItemsModel.ts
+++ b/client/src/ItemsExplorer/ItemsModel.ts
@@ -5,7 +5,7 @@ import {
     workspace
 } from 'vscode'
 import { Item } from './Item'
-import { handleRequestError } from '../Utils'
+import * as utils from '../Utils'
 
 import * as _ from 'lodash'
 import * as request from 'request-promise-native'
@@ -18,7 +18,7 @@ import * as request from 'request-promise-native'
  */
 export class ItemsModel {
 
-    constructor(private host: string) {
+    constructor() {
     }
 
     /**
@@ -37,7 +37,7 @@ export class ItemsModel {
      * @param item openHAB root Item
      */
     public getChildren(item: Item): Thenable<Item[]> {
-        return this.sendRequest(this.host + '/rest/items/' + item.name, (item: Item) => {
+        return this.sendRequest(utils.getHost() + '/rest/items/' + item.name, (item: Item) => {
             let itemsMap = item.members.map(item => new Item(item))
             return this.sort(itemsMap)
         })
@@ -60,18 +60,19 @@ export class ItemsModel {
      */
     private sendRequest(uri: string, transform): Thenable<Item[]> {
         let options = {
-            uri: uri || this.host + '/rest/items',
+            uri: uri || utils.getHost() + '/rest/items',
             json: true,
             encoding: 'utf8'
         }
 
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve, _reject) => {
             request(options)
                 .then(function (response: Item[] | Item) {
                     resolve(transform(response))
                 }.bind(this))
                 .catch(err => {
-                    handleRequestError(err).then(err => resolve([]))
+                    utils.appendToOutput(`Could not reload items for Items Explorer`)
+                    utils.handleRequestError(err).then(err => resolve([]))
                 })
         })
     }

--- a/client/src/ThingsExplorer/ThingsExplorer.ts
+++ b/client/src/ThingsExplorer/ThingsExplorer.ts
@@ -12,7 +12,6 @@ import * as _ from 'lodash'
 import { Channel } from './Channel'
 import { Thing } from './Thing'
 import { ThingsModel } from './ThingsModel'
-import { getHost } from './../Utils'
 
 /**
  * Produces a tree view of openHAB things
@@ -26,11 +25,9 @@ export class ThingsExplorer implements TreeDataProvider<Thing|Channel> {
     readonly onDidChangeTreeData: Event<any> = this._onDidChangeTreeData.event
 
     constructor() {
-        this.openhabHost = getHost()
         this.extensionpath = extensions.getExtension("openhab.openhab").extensionPath
     }
 
-    private openhabHost: string
     private extensionpath: string
 
     private model: ThingsModel
@@ -80,7 +77,7 @@ export class ThingsExplorer implements TreeDataProvider<Thing|Channel> {
     public getChildren(thing?: Thing): Thing[] | Thenable<Thing[]> | Channel[] | Thenable<Channel[]> {
         if (!thing) {
             if (!this.model) {
-                this.model = new ThingsModel(this.openhabHost)
+                this.model = new ThingsModel()
             }
 
             return this.model.roots

--- a/client/src/ThingsExplorer/ThingsModel.ts
+++ b/client/src/ThingsExplorer/ThingsModel.ts
@@ -6,10 +6,11 @@ import {
 } from 'vscode'
 import { Thing } from './Thing'
 import { Channel } from './Channel'
-import { handleRequestError } from '../Utils'
+import * as utils from '../Utils'
 
 import * as _ from 'lodash'
 import * as request from 'request-promise-native'
+
 
 /**
  * Collects Things in JSON format from REST API
@@ -19,7 +20,7 @@ import * as request from 'request-promise-native'
  */
 export class ThingsModel {
 
-    constructor(private host: string) {
+    constructor() {
     }
 
     /**
@@ -41,7 +42,7 @@ export class ThingsModel {
 
     private sendRequest(uri: string, transform): Thenable<Thing[]> {
         let options = {
-            uri: uri || this.host + '/rest/things',
+            uri: uri || utils.getHost() + '/rest/things',
             json: true,
             encoding: 'utf8'
         }
@@ -52,7 +53,8 @@ export class ThingsModel {
                     resolve(this.sort(transform(response)))
                 }.bind(this))
                 .catch(err => {
-                    handleRequestError(err).then(err => resolve([]))
+                    utils.appendToOutput(`Could not reload items for Things Explorer`)
+                    utils.handleRequestError(err).then(err => resolve([]))
                 })
         })
     }

--- a/client/src/Utils.ts
+++ b/client/src/Utils.ts
@@ -135,15 +135,20 @@ export async function handleRequestError(err) {
     let config = workspace.getConfiguration('openhab')
     const setHost = 'Set openHAB host'
     const disableRest = 'Disable REST API'
+    const showOutput = 'Show Output'
 
     // Show error message with action buttons
+    const baseMessage = `Error while connecting to openHAB REST API.`
     const message = typeof err.error === 'string' ? err.error : err.error.message
-    const result = await window.showErrorMessage(`Error while connecting to openHAB REST API. ${message || ''}`, setHost, disableRest)
+    const result = await window.showErrorMessage(`${baseMessage}\nMore information may be found int the openHAB Extension output!`, setHost, disableRest, showOutput)
 
     // Action based on user input
     switch (result) {
         case setHost:
             commands.executeCommand('workbench.action.openWorkspaceSettings')
+            break
+        case showOutput:
+            extensionOutput.show()
             break
         case disableRest:
             config.update('useRestApi', false)
@@ -151,10 +156,18 @@ export async function handleRequestError(err) {
         default:
             break
     }
+
+    appendToOutput(`---
+    Error:
+        ${baseMessage}
+
+    Message:
+        ${message}
+---`)
 }
 
 /**
- * This will send a message frmo the extension to its output channel.
+ * This will send a message from the extension to its output channel.
  * If the channel isn't existing already, it will be created during method run.
  *
  * @param message The message to append to the extensions output Channel

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -45,6 +45,14 @@ let ohStatusBarItem: StatusBarItem
  */
 async function init(disposables: Disposable[], config, context): Promise<void> {
 
+    context.subscriptions.push(workspace.onDidChangeConfiguration(e => {
+
+        // Refresh treeviews when a connection related setting gets changed
+        if(e.affectsConfiguration('openhab.host') || e.affectsConfiguration('openhab.password') || e.affectsConfiguration('openhab.port') || e.affectsConfiguration('openhab.username') ){
+            commands.executeCommand('openhab.command.refreshEntry');
+        }
+    }))
+
     disposables.push(commands.registerCommand('openhab.basicUI', () => {
         let editor = window.activeTextEditor
         if (!editor) {


### PR DESCRIPTION
Fixes #221

This will remove static properties from several locations and replace them with methods to get config values during execution.
This way configuration changes should get reflected immediately.

Additionally this includes a watcher for config changes.
Changes on openHAB connection related configuration parameters will lead to a refresh of the `ItemExplorer` and `ThingsExplorer` now.

It also introduces a bit more extended error handling with some more output, which should hopefully improve supporting.