### PR TITLE
[WIP] Add AuthenticationProvider implementing OAuth2 code flow

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,32 +13,20 @@
                 "axios": "^0.21.1",
                 "copy-paste": "^1.3.0",
                 "lodash": "^4.17.20",
-                "request": "^2.88.2",
-                "request-promise-native": "^1.0.9",
-                "vscode-languageclient": "6.0.0-next.1"
+                "vscode-languageclient": "6.0.0-next.1",
+                "yaml-js": "^0.2.3"
             },
             "devDependencies": {
-                "@types/axios": "^0.14.0",
                 "@types/vscode": "^1.14.0"
             },
             "engines": {
-                "vscode": "^1.37.0"
-            }
-        },
-        "node_modules/@types/axios": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
-            "integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
-            "deprecated": "This is a stub types definition for axios (https://github.com/mzabriskie/axios). axios provides its own type definitions, so you don't need @types/axios installed!",
-            "dev": true,
-            "dependencies": {
-                "axios": "*"
+                "vscode": "^1.54.0"
             }
         },
         "node_modules/@types/vscode": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
-            "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
+            "version": "1.55.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.55.0.tgz",
+            "integrity": "sha512-49hysH7jneTQoSC8TWbAi7nKK9Lc5osQNjmDHVosrcU8o3jecD9GrK0Qyul8q4aGPSXRfNGqIp9CBdb13akETg==",
             "dev": true
         },
         "node_modules/ajv": {
@@ -128,7 +116,8 @@
             "resolved": "https://registry.npmjs.org/copy-paste/-/copy-paste-1.3.0.tgz",
             "integrity": "sha1-p+bEocKP3t8rCB5yuX3y75X0ce0=",
             "dependencies": {
-                "iconv-lite": "^0.4.8"
+                "iconv-lite": "^0.4.8",
+                "sync-exec": "~0.6.x"
             },
             "optionalDependencies": {
                 "sync-exec": "~0.6.x"
@@ -464,11 +453,6 @@
                 "safer-buffer": "^2.0.2",
                 "tweetnacl": "~0.14.0"
             },
-            "bin": {
-                "sshpk-conv": "bin/sshpk-conv",
-                "sshpk-sign": "bin/sshpk-sign",
-                "sshpk-verify": "bin/sshpk-verify"
-            },
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -585,22 +569,18 @@
             "version": "3.15.0-next.5",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.5.tgz",
             "integrity": "sha512-7hrELhTeWieUgex3+6692KjCkcmO/+V/bFItM5MHGcBotzwmjEuXjapLLYTYhIspuJ1ibRSik5MhX5YwLpsPiw=="
+        },
+        "node_modules/yaml-js": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/yaml-js/-/yaml-js-0.2.3.tgz",
+            "integrity": "sha512-6xUQtVKl1qcd0EXtTEzUDVJy9Ji1fYa47LtkDtYKlIjhibPE9knNPmoRyf6SGREFHlOAUyDe9OdYqRP4DuSi5Q=="
         }
     },
     "dependencies": {
-        "@types/axios": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
-            "integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
-            "dev": true,
-            "requires": {
-                "axios": "*"
-            }
-        },
         "@types/vscode": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
-            "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
+            "version": "1.55.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.55.0.tgz",
+            "integrity": "sha512-49hysH7jneTQoSC8TWbAi7nKK9Lc5osQNjmDHVosrcU8o3jecD9GrK0Qyul8q4aGPSXRfNGqIp9CBdb13akETg==",
             "dev": true
         },
         "ajv": {
@@ -877,8 +857,7 @@
             "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "request": {
-            "version": "2.88.2",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "version": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
             "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
             "requires": {
                 "aws-sign2": "~0.7.0",
@@ -912,8 +891,7 @@
             }
         },
         "request-promise-native": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+            "version": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
             "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
             "requires": {
                 "request-promise-core": "1.1.4",
@@ -1037,6 +1015,11 @@
             "version": "3.15.0-next.5",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.5.tgz",
             "integrity": "sha512-7hrELhTeWieUgex3+6692KjCkcmO/+V/bFItM5MHGcBotzwmjEuXjapLLYTYhIspuJ1ibRSik5MhX5YwLpsPiw=="
+        },
+        "yaml-js": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/yaml-js/-/yaml-js-0.2.3.tgz",
+            "integrity": "sha512-6xUQtVKl1qcd0EXtTEzUDVJy9Ji1fYa47LtkDtYKlIjhibPE9knNPmoRyf6SGREFHlOAUyDe9OdYqRP4DuSi5Q=="
         }
     }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     },
     "license": "SEE LICENSE IN LICENSE",
     "engines": {
-        "vscode": "^1.37.0"
+        "vscode": "^1.54.0"
     },
     "scripts": {
         "test": "echo \"No tests in client yet!\""
@@ -21,7 +21,8 @@
         "axios": "^0.21.1",
         "copy-paste": "^1.3.0",
         "lodash": "^4.17.20",
-        "vscode-languageclient": "6.0.0-next.1"
+        "vscode-languageclient": "6.0.0-next.1",
+        "yaml-js": "^0.2.3"
     },
     "devDependencies": {
         "@types/vscode": "^1.14.0"

--- a/client/src/AuthenticationProvider/AuthenticationProvider.ts
+++ b/client/src/AuthenticationProvider/AuthenticationProvider.ts
@@ -1,0 +1,142 @@
+import * as vscode from 'vscode';
+import {
+    authentication,
+    AuthenticationProvider,
+    AuthenticationProviderAuthenticationSessionsChangeEvent,
+    AuthenticationSession,
+    Event,
+    EventEmitter
+} from 'vscode'
+import { v4 as uuid } from 'uuid';
+import {
+    getHost,
+    PromiseAdapter,
+    promiseFromEvent
+} from '../Utils/Utils';
+import axios, { AxiosRequestConfig } from 'axios';
+
+function parseQuery(uri: vscode.Uri) {
+    return uri.query.split('&').reduce((prev: any, current) => {
+        const queryString = current.split('=');
+        prev[queryString[0]] = queryString[1];
+        return prev;
+    }, {});
+}
+
+
+class UriEventHandler extends vscode.EventEmitter<vscode.Uri> implements vscode.UriHandler {
+    public handleUri(uri: vscode.Uri) {
+        this.fire(uri);
+    }
+}
+
+export const uriHandler = new UriEventHandler;
+
+export class OHAuthenticationProvider implements AuthenticationProvider {
+    private _emitter = new EventEmitter<AuthenticationProviderAuthenticationSessionsChangeEvent>()
+    private context: vscode.ExtensionContext
+    private _pendingStates = new Map<string[], string[]>();
+
+    constructor(context: vscode.ExtensionContext) {
+        this.context = context
+    }
+
+    onDidChangeSessions: Event<AuthenticationProviderAuthenticationSessionsChangeEvent> = this._emitter.event
+
+    public async getSessions(scopes?: string[]): Promise<readonly AuthenticationSession[]> {
+        const refreshToken = await this.context.secrets.get('openhab.refreshToken')
+        const clientId = await this.context.secrets.get('openhab.clientId')
+        const host = getHost()
+        if (clientId && refreshToken) {
+            const tokenUrl = `${host}/rest/auth/token`
+            let config: AxiosRequestConfig = {
+                url: host + '/rest/auth/token',
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded'
+                },
+                data: `grant_type=refresh_token&client_id=${encodeURIComponent(clientId.replace('?', '%3F'))}&redirect_uri=${encodeURIComponent(clientId.replace('?', '%3F'))}&refresh_token=${refreshToken}`
+            }
+
+            const result = await axios(config)
+            console.info('Token refresh success!')
+
+            return Promise.resolve([{
+                id: host,
+                account: {
+                    label: 'openHAB',
+                    id: host
+                },
+                scopes: ['admin'],
+                accessToken: result.data.access_token
+            }])
+        } else {
+            return Promise.resolve([])
+        }
+    }
+
+    public async createSession(scopes: string[]): Promise<AuthenticationSession> {
+        const callbackUri = await vscode.env.asExternalUri(vscode.Uri.parse(`${vscode.env.uriScheme}://openhab.openhab/auth`))
+        const host = getHost()
+
+        const state = uuid();
+        const existingStates = this._pendingStates.get(scopes) || [];
+        this._pendingStates.set(scopes, [...existingStates, state]);
+
+        const uri = vscode.Uri.parse(`${host}/auth?response_type=code&client_id=${encodeURIComponent(callbackUri.toString())}&redirect_uri=${encodeURIComponent(callbackUri.toString())}&scope=admin&state=${state}`);
+        await vscode.env.openExternal(uri);
+
+        let codeExchangePromise = promiseFromEvent(uriHandler.event, this.exchangeCodeForToken(host, callbackUri.toString(), callbackUri.toString(), scopes))
+
+        return codeExchangePromise.promise.then((accessToken) => {
+            return Promise.resolve({
+                id: host,
+                account: {
+                    label: 'openHAB',
+                    id: host
+                },
+                scopes: ['admin'],
+                accessToken: accessToken
+            })
+        })
+    }
+
+    public async removeSession(sessionId: string): Promise<void> {
+        return Promise.all([
+            this.context.secrets.delete('openhab.refreshToken'),
+            this.context.secrets.delete('openhab.clientId')
+        ]).then(() => Promise.resolve())
+    }
+
+    private exchangeCodeForToken: (host: string, clientId: string, callbackUri: string, scopes: string[]) => PromiseAdapter<vscode.Uri, string> =
+        (host, clientId, callbackUri, scopes) => async (uri, resolve, reject) => {
+            const query = parseQuery(uri)
+            const code = query.code
+            const acceptedStates = this._pendingStates.get(scopes) || []
+            if (!acceptedStates.includes(query.state)) {
+                reject('Received mismatched state')
+                return
+            }
+
+            try {
+                const tokenUrl = `${host}/rest/auth/token`
+                let config: AxiosRequestConfig = {
+                    url: host + '/rest/auth/token',
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    },
+                    data: `grant_type=authorization_code&client_id=${encodeURIComponent(clientId.replace('?', '%3F'))}&redirect_uri=${encodeURIComponent(callbackUri.replace('?', '%3F'))}&code=${code}`
+                }
+                console.debug(`Exchanging token: calling token endpoint with ${config.data}`)
+                const result = await axios(config)
+                console.info('Token exchange success!')
+                console.info('Saving refresh_token in keychain')
+                this.context.secrets.store('openhab.refreshToken', result.data.refresh_token)
+                this.context.secrets.store('openhab.clientId', clientId)
+                resolve(result.data.access_token)
+            } catch (ex) {
+                reject(ex);
+            }
+        }
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -15,6 +15,7 @@ import { Item } from './ItemsExplorer/Item'
 import { Thing } from './ThingsExplorer/Thing'
 import { Channel } from './ThingsExplorer/Channel'
 import { HoverProvider } from './HoverProvider/HoverProvider'
+import { OHAuthenticationProvider, uriHandler } from './AuthenticationProvider/AuthenticationProvider'
 
 import * as _ from 'lodash'
 import * as ncp from 'copy-paste'
@@ -169,7 +170,6 @@ async function init(disposables: vscode.Disposable[], context: vscode.ExtensionC
                     return ohHoverProvider.getHover(hoveredText, hoveredLine)
                 }
             })
-
         )
 
         // Listen for document save events, to update the cached items
@@ -185,6 +185,10 @@ async function init(disposables: vscode.Disposable[], context: vscode.ExtensionC
                 })
             }
         })
+
+        const authProvider = new OHAuthenticationProvider(context)
+        disposables.push(vscode.window.registerUriHandler(uriHandler));
+        disposables.push(vscode.authentication.registerAuthenticationProvider('openhab', 'openHAB', authProvider))
     }
 
     if (ConfigManager.get(OH_CONFIG_PARAMETERS.languageserver.remoteEnabled) as boolean) {


### PR DESCRIPTION
This is an early implementation of the VS Code Authentication
Provider API which is able to open regular sessions in the
openHAB instance by authorizing itself with the OAuth2 flow,
similarly to the main UI.

When an API request fails, a "Sign in" button is offered to
perform the initial authorization flow (opening a browser to
allow the user to sign in and open a session), the refresh
token is then stored in the keychain (secrets in the extension
context), and reused to get additional access tokens to access
the API on behalf of the user.

It doesn't support yet:

- PKCE challenges
- Normal access token management, for instance refreshing it
  automatically before it expires (after 1 hour)
- Signing out (!)

Signed-off-by: Yannick Schaus <github@schaus.net>