### PR TITLE
Add logging to the console

### DIFF
--- a/client/src/Utils/ConfigManager.ts
+++ b/client/src/Utils/ConfigManager.ts
@@ -246,7 +246,11 @@ Please take a look at the current extension settings\nand update to the new conf
             if(currentConfig.has(parameter)){
                 let inspectresult = currentConfig.inspect(parameter)
                 if(inspectresult.globalValue != undefined || inspectresult.workspaceValue != undefined){
-                     deprecatedParameters.push(parameter)
+                    console.log(`openHAB Extension: Parameter ${parameter} has been recognised as deprecated.\nComplete Parameter Data:\n`)
+                    // console.log(JSON.parse(JSON.stringify(inspectresult)))
+                    console.log(inspectresult)
+
+                    deprecatedParameters.push(parameter)
                 }
             }
         }


### PR DESCRIPTION
Adds some more logging for deprecated parameters to the Developer Tools.

Can be viewed with the following steps:

Open Developer Tools
![image](https://user-images.githubusercontent.com/7161177/115060907-b6b74f00-9ee8-11eb-83de-0464a7a08b91.png)

Go to Console and apply `openhab` filter:
![image](https://user-images.githubusercontent.com/7161177/115061119-085fd980-9ee9-11eb-98da-c8b5fb16024d.png)

Look for following log message types and expand the config info with the little arrow:
![image](https://user-images.githubusercontent.com/7161177/115061309-507efc00-9ee9-11eb-8495-27c7d81490bd.png)

