### PR TITLE
Empty Frame snippet for Sitemap

### DIFF
--- a/snippets/openhab_sitemaps.json
+++ b/snippets/openhab_sitemaps.json
@@ -12,5 +12,14 @@
             "}"
         ],
         "description": "Create a openHAB sitemap"
-    }
+    },
+    
+    "Add new empty Frame": {
+		"prefix": "frame",
+		"body": [
+			"Frame label=\"$1\" ${2|\u200B,icon=\"\" |}{",
+			"\t $3",
+			"}"],
+		"description": "Add new frame with label and optional icon"
+	}
 }


### PR DESCRIPTION
Add snippet with empty Frame with label and icon as an option to the sitemap
Signed-off-by: Glebster-D <47859640+glebster-d@users.noreply.github.com>