### PR TITLE
Update Usage.md to use openhab.connection.authToken

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -60,7 +60,7 @@ You may need to reload the VSCode window to take effect.
 Since openHAB 3 (with its on default activated api authentication) has been released you have to fulllfil some additional steps to get a working connection.
 
 1. [Generate an api token for your user](https://www.openhab.org/docs/configuration/apitokens.html)
-2. Add the generated token as `openhab.connection.basicAuth.username` configuration
+2. Add the generated token as `openhab.connection.authToken` configuration
 3. Leave `openhab.connection.basicAuth.password` empty
 4. Reload vscode window
 


### PR DESCRIPTION
I just started to use openHAB v3.
After following `Usage.md`, I got the following warning:

![image](https://user-images.githubusercontent.com/1270359/150687954-eacd7c23-f734-4c25-856c-2f052a30ad86.png)


Signed-off-by: Christoph Wempe cw-git@wempe.net (github: CWempe)