### PR TITLE
Copilot: Enforce gh CLI usage for issue and PR operations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,17 @@
+## GitHub Issue & Pull Request Operations
+
+Always use the `gh` CLI to interact with GitHub issues and pull requests instead of navigating to GitHub URLs in a browser.
+
+Preferred commands:
+
+- `gh issue view <number>` — fetch issue details
+- `gh issue edit <number> --title "..." --body "..."` — update an issue
+- `gh issue create --title "..." --body "..."` — create an issue
+- `gh issue list` — list issues
+- `gh issue close <number>` — close an issue
+- `gh pr view [<number>]` — fetch PR details
+- `gh pr edit <number> --title "..." --body "..."` — update a PR
+- `gh pr create` — create a PR
+- `gh pr list` — list PRs
+
+Never open a browser page to a GitHub issue or pull request URL to read or edit it.

--- a/.github/hooks/block-github-browser.json
+++ b/.github/hooks/block-github-browser.json
@@ -1,0 +1,11 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": ".github/hooks/block-github-browser.sh",
+        "timeout": 5
+      }
+    ]
+  }
+}

--- a/.github/hooks/block-github-browser.sh
+++ b/.github/hooks/block-github-browser.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block browser navigation to GitHub issue/PR URLs.
+# Instructs the agent to use `gh` CLI instead.
+#
+# Input: JSON on stdin with tool name and parameters.
+# Output: JSON on stdout with permissionDecision.
+
+set -euo pipefail
+
+input=$(cat)
+
+tool_name=$(echo "$input" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('toolName',''))" 2>/dev/null || true)
+
+# Only inspect browser/page navigation tools
+if [[ "$tool_name" != "open_browser_page" && "$tool_name" != "navigate_page" ]]; then
+  exit 0
+fi
+
+url=$(echo "$input" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+params = d.get('toolParameters', d.get('parameters', {}))
+print(params.get('url', ''))
+" 2>/dev/null || true)
+
+if echo "$url" | grep -qE 'github\.com/[^/]+/[^/]+/(issues|pull)/[0-9]+'; then
+  echo '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "permissionDecision": "deny",
+      "permissionDecisionReason": "Use the gh CLI instead of a browser to interact with GitHub issues and pull requests (see copilot-instructions.md). Example: gh issue view <number> or gh pr view <number>."
+    }
+  }'
+  exit 0
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Adds workspace-level Copilot customizations to prevent the agent from opening GitHub issue and pull request URLs in a browser, and redirect it to use the `gh` CLI instead.

## Changes

- `.github/copilot-instructions.md`: workspace instructions listing preferred `gh issue` and `gh pr` commands, with an explicit rule never to open a browser page for GitHub issues or PRs
- `.github/hooks/block-github-browser.json`: registers a `PreToolUse` hook pointing to the blocking script
- `.github/hooks/block-github-browser.sh`: inspects every tool call before execution; denies `open_browser_page` and `navigate_page` calls whose URL matches a GitHub issue or PR pattern, returning a `permissionDecision: deny` with a hint to use `gh` instead