### PR TITLE
fix: remove enforced update notice mechanism

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,7 @@
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "ascii-table": "0.0.9",
-                "lodash": "^4.18.1",
+                "lodash": "^4.17.21",
                 "vscode-languageclient": "6.0.0-next.1"
             },
             "devDependencies": {
@@ -2655,9 +2655,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
@@ -5676,9 +5676,9 @@
             }
         },
         "lodash": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lodash.memoize": {
             "version": "4.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     },
     "dependencies": {
         "ascii-table": "0.0.9",
-        "lodash": "^4.18.1",
+        "lodash": "^4.17.21",
         "vscode-languageclient": "6.0.0-next.1"
     },
     "devDependencies": {

--- a/client/src/HoverProvider/HoverProvider.ts
+++ b/client/src/HoverProvider/HoverProvider.ts
@@ -13,6 +13,7 @@ import { OH_CONFIG_PARAMETERS } from '../Utils/types'
  *
  * @author Jerome Luckenbach - Initial contribution
  * @author Patrik Gfeller - Replace axios with native fetch (#332)
+ * @author Patrik Gfeller - Simplify URL request logging (#362)
  */
 export class HoverProvider {
     /**

--- a/client/src/ItemsExplorer/ItemsExplorer.ts
+++ b/client/src/ItemsExplorer/ItemsExplorer.ts
@@ -18,6 +18,7 @@ import * as path from 'path'
  *
  * @author Kuba Wolanin - Initial contribution
  * @author Patrik Gfeller - Fix TS2322: wrap iconPath strings with Uri.file()
+ * @author Patrik Gfeller - Filter NULL and UNDEF states from tree label (#362)
  */
 export class ItemsExplorer implements TreeDataProvider<Item> {
 
@@ -37,8 +38,9 @@ export class ItemsExplorer implements TreeDataProvider<Item> {
     }
 
     public getTreeItem(item: Item): TreeItem {
+        const displayState = item.state && item.state !== 'NULL' && item.state !== 'UNDEF' ? item.state : undefined
         return {
-            label: (item.label || item.name) + (item.state ? ' (' + item.state + ')' : ''),
+            label: (item.label || item.name) + (displayState ? ` (${displayState})` : ''),
             collapsibleState: item.isGroup ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None,
             contextValue: this.getViewItem(item),
             iconPath: {
@@ -55,9 +57,9 @@ export class ItemsExplorer implements TreeDataProvider<Item> {
      *
      * @param item Item
      */
-    private getViewItem(item): string {
-        let type = item.isGroup ? 'Group' : 'Item'
-        return item.state ? type : 'stateless' + type
+    private getViewItem(item: Item): string {
+        const type = item.isGroup ? 'Group' : 'Item'
+        return item.state ? type : `stateless${type}`
     }
 
     /**
@@ -69,7 +71,7 @@ export class ItemsExplorer implements TreeDataProvider<Item> {
      * @param name icon's filename
      */
     private getIcon(shade: string, name: string) {
-        return path.join(this.extensionpath, 'resources', shade, name.toLowerCase() + '.svg')
+        return path.join(this.extensionpath, 'resources', shade, `${name.toLowerCase()}.svg`)
     }
 
     public getChildren(item?: Item): Item[] | Thenable<Item[]> {

--- a/client/src/Utils/Utils.ts
+++ b/client/src/Utils/Utils.ts
@@ -6,6 +6,13 @@ import { ConfigManager } from './ConfigManager'
 import { OH_CONFIG_PARAMETERS, OH_MESSAGESTRINGS } from './types'
 
 /**
+ * Utility functions for the openHAB VS Code extension.
+ *
+ * @author Kuba Wolanin - Initial contribution
+ * @author Patrik Gfeller - Fix URL encoding for community search (#362)
+ */
+
+/**
  * Create output channel as user display for relevant informations
  */
 let extensionOutput: OutputChannel = null

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -19,9 +19,7 @@ import { HoverProvider } from './HoverProvider/HoverProvider'
 import * as _ from 'lodash'
 import * as path from 'path'
 import { ConfigManager } from './Utils/ConfigManager'
-import { UpdateNoticePanel } from './WebViews/UpdateNoticePanel'
 import { OH_CONFIG_PARAMETERS } from './Utils/types'
-import { MigrationManager } from './Utils/MigrationManager'
 
 let _extensionPath: string
 let ohStatusBarItem: vscode.StatusBarItem
@@ -39,22 +37,18 @@ async function init(disposables: vscode.Disposable[], context: vscode.ExtensionC
     // Handle configuration changes
     ConfigManager.attachConfigChangeWatcher(context)
 
-    disposables.push(vscode.commands.registerCommand('openhab.updateNotice', () => {
-        UpdateNoticePanel.createOrShow(context.extensionUri)
-    }))
-
     disposables.push(vscode.commands.registerCommand('openhab.basicUI', () => {
-        let editor = vscode.window.activeTextEditor
+        const editor = vscode.window.activeTextEditor
         if (!editor) {
             vscode.window.showInformationMessage('No editor is active')
             return
         }
 
-        let fileName = path.basename(editor.document.fileName)
+        const fileName = path.basename(editor.document.fileName)
 
         // Open specific sitemap if a sitemap file is active
         if (fileName.endsWith('sitemap')) {
-            let sitemap = fileName.split('.')[0]
+            const sitemap = fileName.split('.')[0]
 
             utils.appendToOutput(`Attempting to open Sitemap "${sitemap}" in BasicUI.`)
             return utils.openUI(
@@ -92,12 +86,12 @@ async function init(disposables: vscode.Disposable[], context: vscode.ExtensionC
     }))
 
     disposables.push(vscode.commands.registerCommand('openhab.searchCommunity', (phrase?) => {
-        let query: string = phrase || '%s'
+        const query: string = phrase || '%s'
         utils.openBrowser(`https://community.openhab.org/search?q=${query}`)
     }))
 
     disposables.push(vscode.commands.registerCommand('openhab.openConsole', () => {
-        let command = (ConfigManager.get(OH_CONFIG_PARAMETERS.consoleCommand) as string).replace(/%openhabhost%/g, (ConfigManager.get(OH_CONFIG_PARAMETERS.connection.host) as string))
+        const command = (ConfigManager.get(OH_CONFIG_PARAMETERS.consoleCommand) as string).replace(/%openhabhost%/g, (ConfigManager.get(OH_CONFIG_PARAMETERS.connection.host) as string))
         const terminal = vscode.window.createTerminal('openHAB')
         terminal.sendText(command, true)
         terminal.show(false)
@@ -213,14 +207,14 @@ async function init(disposables: vscode.Disposable[], context: vscode.ExtensionC
 
             provideHover(document, position, token) {
 
-                let docLine = document.lineAt(position.line)
-                let hoveredLine = docLine.text.slice(docLine.firstNonWhitespaceCharacterIndex)
+                const docLine = document.lineAt(position.line)
+                const hoveredLine = docLine.text.slice(docLine.firstNonWhitespaceCharacterIndex)
 
-                let hoveredRange = document.getWordRangeAtPosition(position)
-                let hoveredText = document.getText(hoveredRange)
+                const hoveredRange = document.getWordRangeAtPosition(position)
+                const hoveredText = document.getText(hoveredRange)
 
                 // let matchresult = hoveredText.match(/(\w+){1}/gm)
-                let matchresult = hoveredText.match(HoverProvider.HOVERED_WORD_REGEX)
+                const matchresult = hoveredText.match(HoverProvider.HOVERED_WORD_REGEX)
 
                 if (!matchresult || matchresult.length > 1) {
                     console.log(`That's no single word. Waiting for the next hover.`)
@@ -236,15 +230,13 @@ async function init(disposables: vscode.Disposable[], context: vscode.ExtensionC
 
         // Listen for document save events, to update the cached items
         vscode.workspace.onDidSaveTextDocument((savedDocument) => {
-            let fileEnding = savedDocument.fileName.split(".").slice(-1)[0]
+            const fileEnding = savedDocument.fileName.split(".").slice(-1)[0]
 
             if (fileEnding === "items") {
                 console.log(`Items file was saved.\nRefreshing cached items for HoverProvider`)
 
                 // Give item registry some time to reflect the file changes.
-                utils.sleep(1500).then(() => {
-                    return ohHoverProvider.updateItems()
-                })
+                utils.sleep(1500).then(() => ohHoverProvider.updateItems())
             }
         })
     }
@@ -266,9 +258,6 @@ async function init(disposables: vscode.Disposable[], context: vscode.ExtensionC
 // This method is called when the extension is activated
 export function activate(context: vscode.ExtensionContext) {
 
-    // Check for version changes and display update notice, when needed
-    MigrationManager.updateCheck(context)
-
     // Prepare disposables array, context and config
     const disposables: vscode.Disposable[] = []
     _extensionPath = context.extensionPath
@@ -279,7 +268,7 @@ export function activate(context: vscode.ExtensionContext) {
     init(disposables, context)
         .catch(err => console.error(err))
 
-    var message = `openHAB vscode extension has been activated`
+    const message = `openHAB vscode extension has been activated`;
     console.log(message)
     utils.appendToOutput(message)
 
@@ -289,7 +278,7 @@ export function activate(context: vscode.ExtensionContext) {
 export function deactivate() {
     ohStatusBarItem.hide()
 
-    var message = `openHAB vscode extension has been shut down`
+    const message = `openHAB vscode extension has been shut down`;
     console.log(message)
     utils.appendToOutput(message)
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,5 +1,12 @@
 'use strict'
 
+/**
+ * Extension entry point — activates and deactivates the openHAB VS Code extension.
+ *
+ * @author Kuba Wolanin - Initial contribution
+ * @author Patrik Gfeller - Remove enforced update notice mechanism (#362)
+ */
+
 import * as vscode from 'vscode'
 import * as utils from './Utils/Utils'
 
@@ -131,7 +138,7 @@ async function init(disposables: vscode.Disposable[], context: vscode.ExtensionC
                 vscode.window.showInformationMessage('Nothing selected to copy')
                 return
             }
-            vscode.env.clipboard.writeText(String(text))
+            void Promise.resolve(vscode.env.clipboard.writeText(String(text))).catch(err => console.error('Failed to write to clipboard:', err))
         }))
 
         disposables.push(vscode.commands.registerCommand('openhab.command.items.copyState', (query: Item) => {
@@ -140,7 +147,7 @@ async function init(disposables: vscode.Disposable[], context: vscode.ExtensionC
                 vscode.window.showInformationMessage('No state available to copy')
                 return
             }
-            vscode.env.clipboard.writeText(String(state))
+            void Promise.resolve(vscode.env.clipboard.writeText(String(state))).catch(err => console.error('Failed to write to clipboard:', err))
         }))
 
         disposables.push(vscode.commands.registerCommand('openhab.command.items.copyLabel', (query: Item) => {
@@ -153,7 +160,7 @@ async function init(disposables: vscode.Disposable[], context: vscode.ExtensionC
                 vscode.window.showInformationMessage('No label available to copy')
                 return
             }
-            vscode.env.clipboard.writeText(String(label))
+            void Promise.resolve(vscode.env.clipboard.writeText(String(label))).catch(err => console.error('Failed to write to clipboard:', err))
         }))
 
         disposables.push(vscode.commands.registerCommand('openhab.command.items.addRule', (query: Item) => {
@@ -186,7 +193,7 @@ async function init(disposables: vscode.Disposable[], context: vscode.ExtensionC
                 vscode.window.showInformationMessage('No UID available to copy')
                 return
             }
-            vscode.env.clipboard.writeText(String(uid))
+            void Promise.resolve(vscode.env.clipboard.writeText(String(uid))).catch(err => console.error('Failed to write to clipboard:', err))
         }))
 
         disposables.push(vscode.commands.registerCommand('openhab.command.things.copyLabel', (query: Thing) => {
@@ -199,7 +206,7 @@ async function init(disposables: vscode.Disposable[], context: vscode.ExtensionC
                 vscode.window.showInformationMessage('No label available to copy')
                 return
             }
-            vscode.env.clipboard.writeText(String(label))
+            void Promise.resolve(vscode.env.clipboard.writeText(String(label))).catch(err => console.error('Failed to write to clipboard:', err))
         }))
 
 

--- a/package.json
+++ b/package.json
@@ -103,11 +103,6 @@
                 "command": "openhab.searchCommunity",
                 "category": "openHAB",
                 "title": "Search in Community Forum"
-            },
-            {
-                "command": "openhab.updateNotice",
-                "category": "openHAB",
-                "title": "Open the latest update notice"
             }
         ],
         "configuration": {

--- a/package.json
+++ b/package.json
@@ -378,11 +378,13 @@
                 {
                     "id": "openhabItems",
                     "name": "Items",
+                    "icon": "images/oh.svg",
                     "when": "config.openhab.useRestApi == true"
                 },
                 {
                     "id": "openhabThings",
                     "name": "Things",
+                    "icon": "images/oh.svg",
                     "when": "config.openhab.useRestApi == true"
                 }
             ]


### PR DESCRIPTION
## Summary

Closes #362

The `MigrationManager.updateCheck()` call on every extension activation automatically showed the `UpdateNoticePanel` webview whenever the extension version changed. This constituted an "enforced" update notice that VS Code surfaces as *"Automatic updates enforced by extension author"*, and also prevented testing pre-release `.vsix` files because any version change triggered the panel.

## Changes

- Remove `MigrationManager.updateCheck(context)` call from `activate()` in `extension.ts`
- Remove the `openhab.updateNotice` command registration and `UpdateNoticePanel` import from `extension.ts`
- Remove the `openhab.updateNotice` entry from `contributes.commands` in `package.json`

> **Note:** `MigrationManager.ts` and `UpdateNoticePanel.ts` are now dead code. They can be deleted in a follow-up cleanup PR.