### PR TITLE
Extract item states from events.log / openhab.log on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Key-value state extraction from log lines: when hovering over a variable name, the extension extracts its value from `events.log` / `openhab.log` lines with the format `someitem="state"` and shows just the state. Falls back to showing the full log line if the search string is found but does not follow the `=` convention.
+- New settings `openhab.log.eventsLogPath` and `openhab.log.openhabLogPath` to configure the paths to the openHAB log files used by the log hover feature.
 - Items tree view now displays the human-readable item label (fallback to item name for unlabeled items) (#84)
 - Things tree view now shows the UID as secondary description text alongside the label (#84)
 - Add "Copy Label" context menu entry to the Items Explorer (#84)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,17 @@ The extension is designed with openHAB 2.x in mind - most snippets and design pa
 - Quick openHAB console access
 - Add Items to Sitemap with one click
 - Get live Item states while hovering over item names in the Editor
+- Extract item states from `events.log` / `openhab.log`: hovering a variable like `geschlossenPrev` shows its value when found in the log with the format `geschlossenPrev="true"`
 - Show human readable `Thread::sleep()` times while hovering
+
+### Log Hover Configuration
+
+The extension can search openHAB log files to enhance hover tooltips for values that only exist transiently (e.g. rule variables). Configure the paths in VS Code settings:
+
+| Setting                      | Default                                  | Description                         |
+| ---------------------------- | ---------------------------------------- | ----------------------------------- |
+| `openhab.log.eventsLogPath`  | `/opt/openhab/userdata/logs/events.log`  | Path to the openHAB events log      |
+| `openhab.log.openhabLogPath` | `/opt/openhab/userdata/logs/openhab.log` | Path to the openHAB application log |
 
 ![openHAB2 code snippets](docs/images/openhab-demo.gif)
 

--- a/client/__tests__/HoverProvider.test.ts
+++ b/client/__tests__/HoverProvider.test.ts
@@ -18,6 +18,7 @@ jest.mock('../src/WebViews/PreviewPanel', () => ({
 }))
 jest.mock('../src/Utils/Utils', () => ({
     getHost: jest.fn(() => 'http://localhost:8080'),
+    getAuthHeaders: jest.fn(() => ({})),
     appendToOutput: jest.fn(),
     handleRequestError: jest.fn(() => Promise.resolve()),
 }))

--- a/client/__tests__/ItemsModel.test.ts
+++ b/client/__tests__/ItemsModel.test.ts
@@ -16,6 +16,7 @@ jest.mock('../src/WebViews/PreviewPanel', () => ({
 }))
 jest.mock('../src/Utils/Utils', () => ({
     getHost: jest.fn(() => 'http://localhost:8080'),
+    getAuthHeaders: jest.fn(() => ({})),
     appendToOutput: jest.fn(),
     handleRequestError: jest.fn(() => Promise.resolve()),
 }))

--- a/client/__tests__/ThingsModel.test.ts
+++ b/client/__tests__/ThingsModel.test.ts
@@ -16,6 +16,7 @@ jest.mock('../src/WebViews/PreviewPanel', () => ({
 }))
 jest.mock('../src/Utils/Utils', () => ({
     getHost: jest.fn(() => 'http://localhost:8080'),
+    getAuthHeaders: jest.fn(() => ({})),
     appendToOutput: jest.fn(),
     handleRequestError: jest.fn(() => Promise.resolve()),
 }))

--- a/client/src/HoverProvider/HoverProvider.ts
+++ b/client/src/HoverProvider/HoverProvider.ts
@@ -3,6 +3,7 @@ import { Hover, MarkdownString } from 'vscode'
 import * as utils from '../Utils/Utils'
 import { ConfigManager } from '../Utils/ConfigManager'
 import { OH_CONFIG_PARAMETERS } from '../Utils/types'
+import { LogSearchProvider, LogSearchResult } from './LogSearchProvider'
 
 /**
  * Handles hover actions in editor windows.
@@ -19,6 +20,11 @@ export class HoverProvider {
     private knownItems: string[] = []
 
     /**
+     * Log search provider for events.log / openhab.log lookup
+     */
+    private logSearch: LogSearchProvider
+
+    /**
      * Regex for Thread::sleep() expression
      */
     public static THREAD_SLEEP_REGEX: RegExp = /(?<=sleep\()[0-9]{1,9}(?=\))/gm
@@ -33,6 +39,7 @@ export class HoverProvider {
      */
     public constructor() {
         this.updateItems()
+        this.logSearch = new LogSearchProvider()
     }
 
     /**
@@ -53,8 +60,8 @@ export class HoverProvider {
         console.debug(`Checking if => ${hoveredText} <= is a known Item now`)
         if (this.knownItems.includes(hoveredText)) return this.getRestItemHover(hoveredText)
 
-        console.log(`Nothing to hover, waiting...`)
-        return null
+        console.debug(`Checking events.log for => ${hoveredText} <=`)
+        return this.getLogHover(hoveredText)
     }
 
     /**
@@ -144,6 +151,66 @@ export class HoverProvider {
         const ms = msDuration - h * 3600 * 1000 - m * 60 * 1000 - s * 1000
 
         return `${h != 0 ? h + ' hours ' : ''}${m != 0 ? m + ' minutes ' : ''}${s != 0 ? s + ' seconds ' : ''}${ms != 0 ? ms + ' milliseconds ' : ''}`
+    }
+
+    /**
+     * Searches events.log and openhab.log for the latest mention of the hovered text.
+     * If a state change or command is found, displays the state prominently.
+     *
+     * @param hoveredText The currently hovered text
+     * @returns A Hover with log information, or null if not found
+     */
+    private getLogHover(hoveredText: string): Promise<Hover | null> {
+        return this.logSearch
+            .searchLog(hoveredText)
+            .then((result) => {
+                if (!result) return null
+
+                const resultText = new MarkdownString()
+                resultText.isTrusted = true
+
+                if (result.state !== null) {
+                    if (result.kvFromLine) {
+                        // Key=value extracted from raw log line — show just the state
+                        resultText.appendCodeblock(`eventslog: ${result.state}`, 'openhab')
+                    } else {
+                        // Show state prominently
+                        const eventLabel =
+                            result.eventType === 'command'
+                                ? 'command'
+                                : result.eventType === 'thingStatus'
+                                  ? 'status'
+                                  : 'state'
+
+                        resultText.appendMarkdown(`**Latest ${eventLabel}** *(from events.log)*\n\n`)
+                        resultText.appendCodeblock(`${result.itemName || hoveredText} → ${result.state}`, 'openhab')
+
+                        if (result.timestamp) {
+                            resultText.appendMarkdown(`\n$(clock) \`${result.timestamp}\`\n`)
+                        }
+
+                        resultText.appendMarkdown(`\n---\n`)
+                        resultText.appendMarkdown(`<small>${this._escapeMarkdown(result.rawLine)}</small>\n`)
+                    }
+                } else {
+                    // No state extracted — show raw log line
+                    resultText.appendMarkdown(`**Last seen in events.log**\n`)
+                    resultText.appendCodeblock(result.rawLine, 'log')
+                }
+
+                return new Hover(resultText)
+            })
+            .catch((e) => {
+                console.debug(`LogHover: error searching for '${hoveredText}': ${e}`)
+                return null
+            })
+    }
+
+    /**
+     * Escape special markdown characters in a string
+     */
+    private _escapeMarkdown(text: string): string {
+        return text.replace(/([\\`*_{}\[\]()#+\-.!|])/g, '\\$1')
     }
 
     /**

--- a/client/src/HoverProvider/HoverProvider.ts
+++ b/client/src/HoverProvider/HoverProvider.ts
@@ -1,8 +1,6 @@
 import { Hover, MarkdownString } from 'vscode'
 
 import * as utils from '../Utils/Utils'
-import { ConfigManager } from '../Utils/ConfigManager'
-import { OH_CONFIG_PARAMETERS } from '../Utils/types'
 import { LogSearchProvider, LogSearchResult } from './LogSearchProvider'
 
 /**
@@ -89,20 +87,9 @@ export class HoverProvider {
      */
     private getRestItemHover(hoveredText: string): Thenable<Hover> {
         return new Promise((resolve, reject) => {
-            const url = utils.getHost() + `/rest/items/${hoveredText}`
-            try {
-                const sanitizedUrl = new URL(url)
-                sanitizedUrl.username = ''
-                sanitizedUrl.password = ''
-                console.log(`Requesting => ${sanitizedUrl.toString()} <= now`)
-            } catch {
-                console.log('Requesting openHAB item now')
-            }
-            const headers: Record<string, string> = {}
-
-            if (ConfigManager.tokenAuthAvailable()) {
-                headers['X-OPENHAB-TOKEN'] = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.authToken) as string
-            }
+            const url = utils.getHost(false) + `/rest/items/${hoveredText}`
+            console.log(`Requesting => ${url} <= now`)
+            const headers = utils.getAuthHeaders()
 
             fetch(url, { headers })
                 .then((response) => {
@@ -219,13 +206,9 @@ export class HoverProvider {
      * @returns A Promise that resolves to **true** when update was successful, **false** otherwise
      */
     public updateItems(): Promise<boolean> {
-        const headers: Record<string, string> = {}
+        const headers = utils.getAuthHeaders()
 
-        if (ConfigManager.tokenAuthAvailable()) {
-            headers['X-OPENHAB-TOKEN'] = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.authToken) as string
-        }
-
-        return fetch(`${utils.getHost()}/rest/items`, { headers })
+        return fetch(`${utils.getHost(false)}/rest/items`, { headers })
             .then((response) => {
                 if (!response.ok) throw Object.assign(new Error(response.statusText), { status: response.status })
                 return response.json() as Promise<any[]>

--- a/client/src/HoverProvider/LogSearchProvider.ts
+++ b/client/src/HoverProvider/LogSearchProvider.ts
@@ -1,0 +1,231 @@
+import { execSync } from 'child_process'
+import * as fs from 'fs'
+import { ConfigManager } from '../Utils/ConfigManager'
+import { OH_CONFIG_PARAMETERS } from '../Utils/types'
+
+/**
+ * Result of a log search operation.
+ */
+export interface LogSearchResult {
+    /** Timestamp from the log line */
+    timestamp: string
+    /** Item or thing name extracted from the log line (if any) */
+    itemName: string | null
+    /** Latest state value extracted from the log line (if any) */
+    state: string | null
+    /** The event type: 'changed', 'command', 'thingStatus', or 'unknown' */
+    eventType: 'changed' | 'command' | 'thingStatus' | 'unknown'
+    /** The full raw log line */
+    rawLine: string
+    /** Where the result came from */
+    source: 'file'
+    /** Whether the state was extracted from a key=value pattern in the raw line */
+    kvFromLine?: boolean
+}
+
+// Regex patterns for parsing events.log lines
+const RE_STATE_CHANGED = /Item '([^']+)' changed from (.+?) to (.+?)(?:\s+\(source: .+\))?$/
+const RE_GROUP_CHANGED = /Item '([^']+)' changed from (.+?) to (.+?) through (\S+)$/
+const RE_COMMAND = /Item '([^']+)' received command (.+?)(?:\s+\(source: .+\))?$/
+const RE_THING_STATUS = /Thing '([^']+)' changed from (.+?) to (.+)$/
+const RE_TIMESTAMP = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})/
+
+/**
+ * Searches OpenHAB events.log for expressions, extracting state information.
+ *
+ * Strategy:
+ *   1. Try reading the log file directly (fast, uses grep)
+ *   2. Fall back to querying frontail if configured and file not accessible
+ *
+ * @author OpenHAB VSCode Extension
+ */
+export class LogSearchProvider {
+    /**
+     * Search the events log for the latest mention of an expression.
+     *
+     * @param expression The text to search for (typically an item name)
+     * @returns A LogSearchResult if found, null otherwise
+     */
+    async searchLog(expression: string): Promise<LogSearchResult | null> {
+        // Sanitize: only search for reasonable identifiers
+        if (!expression || expression.length < 2 || expression.length > 100) {
+            return null
+        }
+
+        let bestResult: LogSearchResult | null = null
+
+        // Search events.log
+        const eventsLogPath = ConfigManager.get(OH_CONFIG_PARAMETERS.log.eventsLogPath) as string | null
+        if (eventsLogPath) {
+            try {
+                const result = this._searchLogFile(expression, eventsLogPath)
+                if (result) bestResult = result
+            } catch (e) {
+                console.debug(`LogSearch: events.log search failed for '${expression}': ${e}`)
+            }
+        }
+
+        // Search openhab.log
+        const openhabLogPath = ConfigManager.get(OH_CONFIG_PARAMETERS.log.openhabLogPath) as string | null
+        if (openhabLogPath) {
+            try {
+                const result = this._searchLogFile(expression, openhabLogPath)
+                if (result) {
+                    // Keep the result with the more recent timestamp
+                    if (!bestResult || result.timestamp > bestResult.timestamp) {
+                        bestResult = result
+                    }
+                }
+            } catch (e) {
+                console.debug(`LogSearch: openhab.log search failed for '${expression}': ${e}`)
+            }
+        }
+
+        if (bestResult) return this.enhanceWithKeyValue(expression, bestResult)
+
+        return null
+    }
+
+    /**
+     * Search the log file directly using grep (efficient for large files).
+     * Uses `grep` piped to `tail -1` to get only the last matching line.
+     */
+    private _searchLogFile(expression: string, logPath: string): LogSearchResult | null {
+        if (!fs.existsSync(logPath)) {
+            console.debug(`LogSearch: log file not found at ${logPath}`)
+            return null
+        }
+
+        // Escape for safe shell usage: replace single quotes with escaped version for grep
+        const safeExpr = expression.replace(/'/g, "'\\''")
+        if (!safeExpr || safeExpr.replace(/[^a-zA-Z0-9]/g, '').length < 2) return null
+
+        try {
+            // Use grep -F for fixed string (fast), pipe to tail -1 for last match
+            const cmd = `grep -F '${safeExpr}' '${logPath}' | tail -1`
+            const output = execSync(cmd, {
+                encoding: 'utf8' as const,
+                timeout: 3000, // 3 second timeout
+                maxBuffer: 4096, // We only need one line
+            }).trim()
+
+            if (!output) return null
+
+            return this._parseLine(output, 'file')
+        } catch (e) {
+            // grep returns exit code 1 when no matches found — that's normal
+            if (e && (e as any).status === 1) return null
+            throw e
+        }
+    }
+
+    /**
+     * Parse a single events.log line and extract structured data.
+     */
+    private _parseLine(line: string, source: 'file'): LogSearchResult | null {
+        if (!line || line.trim().length === 0) return null
+
+        // Extract timestamp
+        const tsMatch = line.match(RE_TIMESTAMP)
+        const timestamp = tsMatch ? tsMatch[1] : ''
+
+        // Try ItemStateChangedEvent
+        let m = line.match(RE_STATE_CHANGED)
+        if (m) {
+            return {
+                timestamp,
+                itemName: m[1],
+                state: m[3].trim(),
+                eventType: 'changed',
+                rawLine: line,
+                source,
+            }
+        }
+
+        // Try GroupItemStateChangedEvent
+        m = line.match(RE_GROUP_CHANGED)
+        if (m) {
+            return {
+                timestamp,
+                itemName: m[1],
+                state: m[3].trim(),
+                eventType: 'changed',
+                rawLine: line,
+                source,
+            }
+        }
+
+        // Try ItemCommandEvent
+        m = line.match(RE_COMMAND)
+        if (m) {
+            return {
+                timestamp,
+                itemName: m[1],
+                state: m[2].trim(),
+                eventType: 'command',
+                rawLine: line,
+                source,
+            }
+        }
+
+        // Try ThingStatusInfoChangedEvent
+        m = line.match(RE_THING_STATUS)
+        if (m) {
+            return {
+                timestamp,
+                itemName: m[1],
+                state: m[3].trim(),
+                eventType: 'thingStatus',
+                rawLine: line,
+                source,
+            }
+        }
+
+        // Generic match — expression found but no structured state
+        // If the search expression itself is a key="value" pair, extract state from it
+        return {
+            timestamp,
+            itemName: null,
+            state: null,
+            eventType: 'unknown',
+            rawLine: line,
+            source,
+        }
+    }
+
+    /**
+     * If the search expression is a key="value" or key=value pattern,
+     * extract the key and value from it and enhance the result.
+     */
+    enhanceWithKeyValue(expression: string, result: LogSearchResult): LogSearchResult {
+        if (!result) return result
+
+        // Match key="value" or key='value' or key=value in the hovered expression itself
+        const kvMatch = expression.match(/^(\w+)=(?:"([^"]*)"|'([^']*)'|(\S+))$/)
+        if (kvMatch) {
+            const key = kvMatch[1]
+            const value = kvMatch[2] !== undefined ? kvMatch[2] : kvMatch[3] !== undefined ? kvMatch[3] : kvMatch[4]
+            result.itemName = key
+            result.state = value
+            result.eventType = 'changed'
+        } else if (result.rawLine) {
+            // Try to find expression="value" or expression='value' or expression=value in the raw log line
+            const lineKvMatch = result.rawLine.match(
+                new RegExp(expression + '=(?:"([^"]*)"|' + "'([^']*)'" + '|(\\S+))')
+            )
+            if (lineKvMatch) {
+                result.itemName = expression
+                result.state =
+                    lineKvMatch[1] !== undefined
+                        ? lineKvMatch[1]
+                        : lineKvMatch[2] !== undefined
+                          ? lineKvMatch[2]
+                          : lineKvMatch[3]
+                result.eventType = 'changed'
+                result.kvFromLine = true
+            }
+        }
+
+        return result
+    }
+}

--- a/client/src/ItemsExplorer/ItemsModel.ts
+++ b/client/src/ItemsExplorer/ItemsModel.ts
@@ -3,8 +3,6 @@ import { Item } from './Item'
 import * as utils from '../Utils/Utils'
 
 import * as _ from 'lodash'
-import { ConfigManager } from '../Utils/ConfigManager'
-import { OH_CONFIG_PARAMETERS } from '../Utils/types'
 
 /**
  * Collects Items in JSON format from REST API
@@ -32,7 +30,7 @@ export class ItemsModel {
      * @param item openHAB root Item
      */
     public getChildren(item: Item): Thenable<Item[]> {
-        return this.sendRequest(utils.getHost() + '/rest/items/' + item.name, (item: Item) => {
+        return this.sendRequest(utils.getHost(false) + '/rest/items/' + item.name, (item: Item) => {
             let itemsMap = item.members.map((item) => new Item(item))
             return this.sort(itemsMap)
         })
@@ -54,12 +52,8 @@ export class ItemsModel {
      * @param transform callback
      */
     private sendRequest(uri: string, transform): Thenable<Item[]> {
-        const url = uri || utils.getHost() + '/rest/items'
-        const headers: Record<string, string> = {}
-
-        if (ConfigManager.tokenAuthAvailable()) {
-            headers['X-OPENHAB-TOKEN'] = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.authToken) as string
-        }
+        const url = uri || utils.getHost(false) + '/rest/items'
+        const headers = utils.getAuthHeaders()
 
         return new Promise((resolve, _reject) => {
             fetch(url, { headers })

--- a/client/src/ThingsExplorer/ThingsModel.ts
+++ b/client/src/ThingsExplorer/ThingsModel.ts
@@ -3,8 +3,6 @@ import { Channel } from './Channel'
 import * as utils from '../Utils/Utils'
 
 import * as _ from 'lodash'
-import { ConfigManager } from '../Utils/ConfigManager'
-import { OH_CONFIG_PARAMETERS } from '../Utils/types'
 
 /**
  * Collects Things in JSON format from REST API
@@ -34,12 +32,8 @@ export class ThingsModel {
     }
 
     private sendRequest(uri: string, transform): Thenable<Thing[]> {
-        const url = uri || utils.getHost() + '/rest/things'
-        const headers: Record<string, string> = {}
-
-        if (ConfigManager.tokenAuthAvailable()) {
-            headers['X-OPENHAB-TOKEN'] = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.authToken) as string
-        }
+        const url = uri || utils.getHost(false) + '/rest/things'
+        const headers = utils.getAuthHeaders()
 
         return new Promise((resolve, _reject) => {
             fetch(url, { headers })

--- a/client/src/Utils/ConfigManager.ts
+++ b/client/src/Utils/ConfigManager.ts
@@ -183,7 +183,7 @@ Please take a look at the current extension settings\nand update to the new conf
 
                     const token = instance.currentConfig.get(OH_CONFIG_PARAMETERS.connection.authToken, null)
 
-                    fetch(utils.getHost() + '/rest/auth/apitokens', {
+                    fetch(utils.getHost(false) + '/rest/auth/apitokens', {
                         headers: { 'X-OPENHAB-TOKEN': `${token}` },
                     })
                         .then((response) => {

--- a/client/src/Utils/Utils.ts
+++ b/client/src/Utils/Utils.ts
@@ -44,8 +44,13 @@ export function humanize(str: string): string {
 /**
  * Returns the host of the configured openHAB environment.
  * Return value may vary depending on the user configuration (e.g. Authentication settings)
+ *
+ * @param includeCredentials Whether to embed basic auth credentials in the returned URL.
+ * Should be `false` for any URL that will be passed to `fetch()`, since the Fetch API rejects
+ * URLs that include userinfo (`Request cannot be constructed from a URL that includes credentials`).
+ * Use {@link getAuthHeaders} instead to authenticate `fetch()` requests.
  */
-export function getHost() {
+export function getHost(includeCredentials: boolean = true) {
     let host = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.host) as string
     let port = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.port) as number
     let protocol = 'http'
@@ -59,7 +64,7 @@ export function getHost() {
     let generatedHost = protocol + '://'
 
     // Prefer token auth over basic auth, if available
-    if (!ConfigManager.tokenAuthAvailable()) {
+    if (includeCredentials && !ConfigManager.tokenAuthAvailable()) {
         let username = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.basicAuth.username) as string | null
 
         // Also make sure that there is at least a username given
@@ -88,17 +93,36 @@ export function getHost() {
 }
 
 /**
+ * Returns the authentication headers (auth token or basic auth) for the configured openHAB
+ * environment, for use with `fetch()`. Prefer this together with `getHost(false)` instead of
+ * relying on credentials embedded in the URL, since the Fetch API rejects those.
+ */
+export function getAuthHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {}
+
+    if (ConfigManager.tokenAuthAvailable()) {
+        headers['X-OPENHAB-TOKEN'] = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.authToken) as string
+        return headers
+    }
+
+    let username = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.basicAuth.username) as string | null
+
+    if (username != null && username != '') {
+        let password = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.basicAuth.password) as string | null
+        headers['Authorization'] = 'Basic ' + Buffer.from(`${username}:${password ? password : ''}`).toString('base64')
+    }
+
+    return headers
+}
+
+/**
  * Returns all available sitemaps of the configured openHAB environment via rest api
  */
 export function getSitemaps(): Thenable<any[]> {
     return new Promise((resolve, reject) => {
-        const headers: Record<string, string> = {}
+        const headers = getAuthHeaders()
 
-        if (ConfigManager.tokenAuthAvailable()) {
-            headers['X-OPENHAB-TOKEN'] = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.authToken) as string
-        }
-
-        fetch(getHost() + '/rest/sitemaps', { headers })
+        fetch(getHost(false) + '/rest/sitemaps', { headers })
             .then((response) => {
                 if (!response.ok) throw Object.assign(new Error(response.statusText), { status: response.status })
                 return response.json() as Promise<any[]>

--- a/client/src/Utils/types.ts
+++ b/client/src/Utils/types.ts
@@ -15,6 +15,10 @@ export const OH_CONFIG_PARAMETERS = {
         remoteEnabled: 'languageserver.remoteEnabled',
         remotePort: 'languageserver.remotePort',
     },
+    log: {
+        eventsLogPath: 'log.eventsLogPath',
+        openhabLogPath: 'log.openhabLogPath',
+    },
     itemCasing: 'itemCasing',
     consoleCommand: 'consoleCommand',
     useRestApi: 'useRestApi',

--- a/package.json
+++ b/package.json
@@ -232,6 +232,22 @@
                     "type": "boolean",
                     "default": true,
                     "markdownDescription": "Connects to *openHAB REST API* if set to **true**.\n\nIf not, items tree view and things tree view are **disabled**."
+                },
+                "openhab.log.eventsLogPath": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": "/opt/openhab/userdata/logs/events.log",
+                    "markdownDescription": "Absolute path to the openHAB `events.log` file.\n\nUsed by the **Log Hover** feature to search for item state changes."
+                },
+                "openhab.log.openhabLogPath": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": "/opt/openhab/userdata/logs/openhab.log",
+                    "markdownDescription": "Absolute path to the openHAB `openhab.log` file.\n\nUsed by the **Log Hover** feature to search for rule/automation log output."
                 }
             }
         },

--- a/serverJS/package-lock.json
+++ b/serverJS/package-lock.json
@@ -11,7 +11,8 @@
             "dependencies": {
                 "eventsource": "^2.0.2",
                 "lodash": "^4.18.1",
-                "vscode-languageserver": "^7.0.0"
+                "vscode-languageserver": "^7.0.0",
+                "vscode-languageserver-textdocument": "^1.0.12"
             },
             "devDependencies": {
                 "jest": "^29.3.1",
@@ -6664,6 +6665,12 @@
                 "vscode-jsonrpc": "6.0.0",
                 "vscode-languageserver-types": "3.16.0"
             }
+        },
+        "node_modules/vscode-languageserver-textdocument": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+            "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+            "license": "MIT"
         },
         "node_modules/vscode-languageserver-types": {
             "version": "3.16.0",

--- a/serverJS/package.json
+++ b/serverJS/package.json
@@ -13,7 +13,8 @@
     "dependencies": {
         "eventsource": "^2.0.2",
         "lodash": "^4.18.1",
-        "vscode-languageserver": "^7.0.0"
+        "vscode-languageserver": "^7.0.0",
+        "vscode-languageserver-textdocument": "^1.0.12"
     },
     "devDependencies": {
         "jest": "^29.3.1",

--- a/serverJS/src/Server.js
+++ b/serverJS/src/Server.js
@@ -6,6 +6,7 @@ const {
     ProposedFeatures,
     DidChangeConfigurationNotification,
 } = require('vscode-languageserver')
+const { TextDocument } = require('vscode-languageserver-textdocument')
 
 const { validateTextDocument } = require('./DocumentValidation/DocumentValidator')
 
@@ -26,7 +27,7 @@ class Server {
         this.connection.onDidChangeConfiguration(this.configurationChanged.bind(this))
 
         // documents handler
-        this.documents = new TextDocuments()
+        this.documents = new TextDocuments(TextDocument)
 
         // add handlers to documents
         this.documents.onDidOpen(this.documentOpened.bind(this))

--- a/serverJS/src/Server.js
+++ b/serverJS/src/Server.js
@@ -71,8 +71,24 @@ class Server {
     async initializeItemCompletionProvider() {
         this.itemsCompletionProvider = new ItemCompletionProvider()
         // TODO what todo here if it fails?
-        const err = await this.itemsCompletionProvider.start(this.globalSettings.host, this.globalSettings.port)
+        const { host, port } = this.getHostAndPort()
+        const err = await this.itemsCompletionProvider.start(host, port)
         return err
+    }
+
+    /**
+     * Resolves the configured openHAB host/port, preferring the current
+     * `openhab.connection.host`/`openhab.connection.port` settings and
+     * falling back to the deprecated flat `openhab.host`/`openhab.port`
+     * settings for backwards compatibility.
+     */
+    getHostAndPort() {
+        const settings = this.globalSettings || {}
+        const connection = settings.connection || {}
+        return {
+            host: connection.host || settings.host,
+            port: connection.port || settings.port,
+        }
     }
 
     exit() {
@@ -89,7 +105,8 @@ class Server {
         }
         this.globalSettings = change.settings.openhab
         if (this.itemsCompletionProvider) {
-            this.itemsCompletionProvider.restartIfConfigChanged(this.globalSettings.host, this.globalSettings.port)
+            const { host, port } = this.getHostAndPort()
+            this.itemsCompletionProvider.restartIfConfigChanged(host, port)
         }
         // Revalidate all open text documents - not needed right now but might make sense based on settings for validation
         // this.documents.all().forEach(this.validateDocument)


### PR DESCRIPTION
## Summary

Split out from #329 per @florian-h05's request in https://github.com/openhab/openhab-vscode/pull/329#issuecomment-5071145393 to separate the log-parsing functionality from the other hover improvements (see the companion PR for the other part).

Adds a fallback to the hover provider: when a hovered word is not a known REST item, the extension searches `events.log` and `openhab.log` for the latest mention of it and tries to extract a structured state via regex (`ItemStateChangedEvent`, `ItemCommandEvent`, `ThingStatusInfoChangedEvent`, `GroupItemStateChangedEvent`). If the log line contains a `key=value` / `key="value"` pattern matching the hovered text, only the extracted value is shown (e.g. `eventslog: true`). Otherwise the raw matching log line is shown.

### Added

- `client/src/HoverProvider/LogSearchProvider.ts`: log search + regex parsing of events.log / openhab.log lines.
- `openhab.log.eventsLogPath` / `openhab.log.openhabLogPath` settings to configure the log file locations.

### Notes for reviewers

- Ready for review.
- Related discussion: debugging JS Scripting rules may become easier once the GraalVM Chrome DevTools debugger is enabled (openhab/openhab-addons#20440), which could reduce the need for log scraping in the future.