### PR TITLE
Hover tooltips for JS/sitemap files, item=<name> fix, widget syntax updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Hover tooltips (state lookups from the REST API) now work in `.js` automation files, not just `.items` and `.rules` files.
+- Hover tooltips work in `.sitemap` files, including `item=<name>` references on widget lines.
+- Syntax highlighting and snippet updates for additional sitemap widget types (`Buttongrid`, `Button`, `Colortemperaturepicker`, `Input`, `Mapview`) and dimensioned `Number:` item types (#328).
 - Items tree view now displays the human-readable item label (fallback to item name for unlabeled items) (#84)
 - Things tree view now shows the UID as secondary description text alongside the label (#84)
 - Add "Copy Label" context menu entry to the Items Explorer (#84)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Visual Studio Marketplace Downloads)][MarketplaceDownloadBadgeImage]][MarketplaceDownloadBadgeImageLink]
 [![Open VSX Downloads][openVsxDownloadBadgeImage]][openVsxDownloadBadgeImageLink]
 
-[openHAB](http://www.openhab.org) is a vendor and techology agnostic open source automation software for your home. This [Visual Studio Code](https://code.visualstudio.com) extension allows you to work with openHAB configuration files (like `*.items`, `*.rules`, `*.sitemap` and `*.script`) thanks to the syntax highlighting, code snippets and integrated search.
+[openHAB](http://www.openhab.org) is a vendor and techology agnostic open source automation software for your home. This [Visual Studio Code](https://code.visualstudio.com) extension allows you to work with openHAB configuration files (like `*.items`, `*.rules`, `*.sitemap`, `*.script` and JavaScript automation files `*.js`) thanks to the syntax highlighting, code snippets and integrated search.
 
 The extension is designed with openHAB 2.x in mind - most snippets and design patterns will work in openHAB 2.x
 
@@ -24,6 +24,7 @@ The extension is designed with openHAB 2.x in mind - most snippets and design pa
 - Quick openHAB console access
 - Add Items to Sitemap with one click
 - Get live Item states while hovering over item names in the Editor
+- Hover tooltips for item names in JavaScript automation files (`.js`) and sitemap files (`.sitemap`), including `item=<name>` references
 - Show human readable `Thread::sleep()` times while hovering
 
 ![openHAB2 code snippets](docs/images/openhab-demo.gif)

--- a/client/__tests__/HoverProvider.test.ts
+++ b/client/__tests__/HoverProvider.test.ts
@@ -18,6 +18,7 @@ jest.mock('../src/WebViews/PreviewPanel', () => ({
 }))
 jest.mock('../src/Utils/Utils', () => ({
     getHost: jest.fn(() => 'http://localhost:8080'),
+    getAuthHeaders: jest.fn(() => ({})),
     appendToOutput: jest.fn(),
     handleRequestError: jest.fn(() => Promise.resolve()),
 }))

--- a/client/__tests__/ItemsModel.test.ts
+++ b/client/__tests__/ItemsModel.test.ts
@@ -16,6 +16,7 @@ jest.mock('../src/WebViews/PreviewPanel', () => ({
 }))
 jest.mock('../src/Utils/Utils', () => ({
     getHost: jest.fn(() => 'http://localhost:8080'),
+    getAuthHeaders: jest.fn(() => ({})),
     appendToOutput: jest.fn(),
     handleRequestError: jest.fn(() => Promise.resolve()),
 }))

--- a/client/__tests__/ThingsModel.test.ts
+++ b/client/__tests__/ThingsModel.test.ts
@@ -16,6 +16,7 @@ jest.mock('../src/WebViews/PreviewPanel', () => ({
 }))
 jest.mock('../src/Utils/Utils', () => ({
     getHost: jest.fn(() => 'http://localhost:8080'),
+    getAuthHeaders: jest.fn(() => ({})),
     appendToOutput: jest.fn(),
     handleRequestError: jest.fn(() => Promise.resolve()),
 }))

--- a/client/src/HoverProvider/HoverProvider.ts
+++ b/client/src/HoverProvider/HoverProvider.ts
@@ -25,8 +25,9 @@ export class HoverProvider {
 
     /**
      * Regex for all hover-relevant wordings
+     * Matches: sleep(nnn), key="value", key='value', key=value, or plain words
      */
-    public static HOVERED_WORD_REGEX: RegExp = /(?<=sleep\()[0-9]{1,9}(?=\)){1}|(\w+){1}/gm
+    public static HOVERED_WORD_REGEX: RegExp = /(?<=sleep\()[0-9]{1,9}(?=\)){1}|\w+=(?:"[^"]*"|'[^']*'|\S+)|\w+/gm
 
     /**
      * Only allow the class to call the constructor
@@ -50,8 +51,13 @@ export class HoverProvider {
 
         if (lineMatch && lineMatch.length == 1) return this.getReadableThreadSleep(hoveredLine)
 
-        console.debug(`Checking if => ${hoveredText} <= is a known Item now`)
-        if (this.knownItems.includes(hoveredText)) return this.getRestItemHover(hoveredText)
+        // If hoveredText is a key=value pair (e.g. item=FF_Bath_Light or label="My Label"),
+        // extract the value for item lookup so sitemap/rules references like item=X work correctly.
+        const kvMatch = hoveredText.match(/^\w+=(?:"([^"]*)"|'([^']*)'|(\S+))$/)
+        const lookupText = kvMatch ? (kvMatch[1] ?? kvMatch[2] ?? kvMatch[3]) : hoveredText
+
+        console.debug(`Checking if => ${lookupText} <= is a known Item now`)
+        if (this.knownItems.includes(lookupText)) return this.getRestItemHover(lookupText)
 
         console.log(`Nothing to hover, waiting...`)
         return null

--- a/client/src/HoverProvider/HoverProvider.ts
+++ b/client/src/HoverProvider/HoverProvider.ts
@@ -51,7 +51,7 @@ export class HoverProvider {
 
         // If hoveredText is a key=value pair (e.g. item=FF_Bath_Light or label="My Label"),
         // extract the value for item lookup so sitemap/rules references like item=X work correctly.
-        const kvMatch = hoveredText.match(/^\w+=(?:"([^"]*)"|'([^']*)'|(\S+))$/)
+        const kvMatch = hoveredText.match(/^\w+=(?:"([^"]*)"|'([^']*)'|(\w+))$/)
         const lookupText = kvMatch ? (kvMatch[1] ?? kvMatch[2] ?? kvMatch[3]) : hoveredText
 
         console.debug(`Checking if => ${lookupText} <= is a known Item now`)

--- a/client/src/HoverProvider/HoverProvider.ts
+++ b/client/src/HoverProvider/HoverProvider.ts
@@ -1,8 +1,6 @@
 import { Hover, MarkdownString } from 'vscode'
 
 import * as utils from '../Utils/Utils'
-import { ConfigManager } from '../Utils/ConfigManager'
-import { OH_CONFIG_PARAMETERS } from '../Utils/types'
 
 /**
  * Handles hover actions in editor windows.
@@ -88,20 +86,9 @@ export class HoverProvider {
      */
     private getRestItemHover(hoveredText: string): Thenable<Hover> {
         return new Promise((resolve, reject) => {
-            const url = utils.getHost() + `/rest/items/${hoveredText}`
-            try {
-                const sanitizedUrl = new URL(url)
-                sanitizedUrl.username = ''
-                sanitizedUrl.password = ''
-                console.log(`Requesting => ${sanitizedUrl.toString()} <= now`)
-            } catch {
-                console.log('Requesting openHAB item now')
-            }
-            const headers: Record<string, string> = {}
-
-            if (ConfigManager.tokenAuthAvailable()) {
-                headers['X-OPENHAB-TOKEN'] = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.authToken) as string
-            }
+            const url = utils.getHost(false) + `/rest/items/${hoveredText}`
+            console.log(`Requesting => ${url} <= now`)
+            const headers = utils.getAuthHeaders()
 
             fetch(url, { headers })
                 .then((response) => {
@@ -158,13 +145,9 @@ export class HoverProvider {
      * @returns A Promise that resolves to **true** when update was successful, **false** otherwise
      */
     public updateItems(): Promise<boolean> {
-        const headers: Record<string, string> = {}
+        const headers = utils.getAuthHeaders()
 
-        if (ConfigManager.tokenAuthAvailable()) {
-            headers['X-OPENHAB-TOKEN'] = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.authToken) as string
-        }
-
-        return fetch(`${utils.getHost()}/rest/items`, { headers })
+        return fetch(`${utils.getHost(false)}/rest/items`, { headers })
             .then((response) => {
                 if (!response.ok) throw Object.assign(new Error(response.statusText), { status: response.status })
                 return response.json() as Promise<any[]>

--- a/client/src/ItemsExplorer/ItemsModel.ts
+++ b/client/src/ItemsExplorer/ItemsModel.ts
@@ -3,8 +3,6 @@ import { Item } from './Item'
 import * as utils from '../Utils/Utils'
 
 import * as _ from 'lodash'
-import { ConfigManager } from '../Utils/ConfigManager'
-import { OH_CONFIG_PARAMETERS } from '../Utils/types'
 
 /**
  * Collects Items in JSON format from REST API
@@ -32,7 +30,7 @@ export class ItemsModel {
      * @param item openHAB root Item
      */
     public getChildren(item: Item): Thenable<Item[]> {
-        return this.sendRequest(utils.getHost() + '/rest/items/' + item.name, (item: Item) => {
+        return this.sendRequest(utils.getHost(false) + '/rest/items/' + item.name, (item: Item) => {
             let itemsMap = item.members.map((item) => new Item(item))
             return this.sort(itemsMap)
         })
@@ -54,12 +52,8 @@ export class ItemsModel {
      * @param transform callback
      */
     private sendRequest(uri: string, transform): Thenable<Item[]> {
-        const url = uri || utils.getHost() + '/rest/items'
-        const headers: Record<string, string> = {}
-
-        if (ConfigManager.tokenAuthAvailable()) {
-            headers['X-OPENHAB-TOKEN'] = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.authToken) as string
-        }
+        const url = uri || utils.getHost(false) + '/rest/items'
+        const headers = utils.getAuthHeaders()
 
         return new Promise((resolve, _reject) => {
             fetch(url, { headers })

--- a/client/src/ThingsExplorer/ThingsModel.ts
+++ b/client/src/ThingsExplorer/ThingsModel.ts
@@ -3,8 +3,6 @@ import { Channel } from './Channel'
 import * as utils from '../Utils/Utils'
 
 import * as _ from 'lodash'
-import { ConfigManager } from '../Utils/ConfigManager'
-import { OH_CONFIG_PARAMETERS } from '../Utils/types'
 
 /**
  * Collects Things in JSON format from REST API
@@ -34,12 +32,8 @@ export class ThingsModel {
     }
 
     private sendRequest(uri: string, transform): Thenable<Thing[]> {
-        const url = uri || utils.getHost() + '/rest/things'
-        const headers: Record<string, string> = {}
-
-        if (ConfigManager.tokenAuthAvailable()) {
-            headers['X-OPENHAB-TOKEN'] = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.authToken) as string
-        }
+        const url = uri || utils.getHost(false) + '/rest/things'
+        const headers = utils.getAuthHeaders()
 
         return new Promise((resolve, _reject) => {
             fetch(url, { headers })

--- a/client/src/Utils/ConfigManager.ts
+++ b/client/src/Utils/ConfigManager.ts
@@ -183,7 +183,7 @@ Please take a look at the current extension settings\nand update to the new conf
 
                     const token = instance.currentConfig.get(OH_CONFIG_PARAMETERS.connection.authToken, null)
 
-                    fetch(utils.getHost() + '/rest/auth/apitokens', {
+                    fetch(utils.getHost(false) + '/rest/auth/apitokens', {
                         headers: { 'X-OPENHAB-TOKEN': `${token}` },
                     })
                         .then((response) => {

--- a/client/src/Utils/Utils.ts
+++ b/client/src/Utils/Utils.ts
@@ -44,8 +44,13 @@ export function humanize(str: string): string {
 /**
  * Returns the host of the configured openHAB environment.
  * Return value may vary depending on the user configuration (e.g. Authentication settings)
+ *
+ * @param includeCredentials Whether to embed basic auth credentials in the returned URL.
+ * Should be `false` for any URL that will be passed to `fetch()`, since the Fetch API rejects
+ * URLs that include userinfo (`Request cannot be constructed from a URL that includes credentials`).
+ * Use {@link getAuthHeaders} instead to authenticate `fetch()` requests.
  */
-export function getHost() {
+export function getHost(includeCredentials: boolean = true) {
     let host = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.host) as string
     let port = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.port) as number
     let protocol = 'http'
@@ -59,7 +64,7 @@ export function getHost() {
     let generatedHost = protocol + '://'
 
     // Prefer token auth over basic auth, if available
-    if (!ConfigManager.tokenAuthAvailable()) {
+    if (includeCredentials && !ConfigManager.tokenAuthAvailable()) {
         let username = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.basicAuth.username) as string | null
 
         // Also make sure that there is at least a username given
@@ -88,17 +93,36 @@ export function getHost() {
 }
 
 /**
+ * Returns the authentication headers (auth token or basic auth) for the configured openHAB
+ * environment, for use with `fetch()`. Prefer this together with `getHost(false)` instead of
+ * relying on credentials embedded in the URL, since the Fetch API rejects those.
+ */
+export function getAuthHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {}
+
+    if (ConfigManager.tokenAuthAvailable()) {
+        headers['X-OPENHAB-TOKEN'] = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.authToken) as string
+        return headers
+    }
+
+    let username = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.basicAuth.username) as string | null
+
+    if (username != null && username != '') {
+        let password = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.basicAuth.password) as string | null
+        headers['Authorization'] = 'Basic ' + Buffer.from(`${username}:${password ? password : ''}`).toString('base64')
+    }
+
+    return headers
+}
+
+/**
  * Returns all available sitemaps of the configured openHAB environment via rest api
  */
 export function getSitemaps(): Thenable<any[]> {
     return new Promise((resolve, reject) => {
-        const headers: Record<string, string> = {}
+        const headers = getAuthHeaders()
 
-        if (ConfigManager.tokenAuthAvailable()) {
-            headers['X-OPENHAB-TOKEN'] = ConfigManager.get(OH_CONFIG_PARAMETERS.connection.authToken) as string
-        }
-
-        fetch(getHost() + '/rest/sitemaps', { headers })
+        fetch(getHost(false) + '/rest/sitemaps', { headers })
             .then((response) => {
                 if (!response.ok) throw Object.assign(new Error(response.statusText), { status: response.status })
                 return response.json() as Promise<any[]>

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -252,10 +252,30 @@ async function init(disposables: vscode.Disposable[], context: vscode.ExtensionC
                         const hoveredLine = docLine.text.slice(docLine.firstNonWhitespaceCharacterIndex)
 
                         // Try to match a key="value" / key=value pair first (e.g. item=FF_Bath_Light in
-                        // sitemap files), then fall back to matching a plain word.
-                        const hoveredRange =
-                            document.getWordRangeAtPosition(position, /\w+=(?:"[^"]*"|'[^']*'|\S+)/) ||
-                            document.getWordRangeAtPosition(position)
+                        // sitemap files). The unquoted value alternative is restricted to identifier
+                        // characters (`\w+`) instead of `\S+`, otherwise it would greedily swallow a
+                        // directly-following character like `{` (e.g. `item=gEHZStatistik{`).
+                        // HoverProvider.getHover() extracts the actual value from this key=value text
+                        // itself, so it is passed straight through without running it through the
+                        // single-word sanity check below (which would otherwise always reject it, since
+                        // "key" and "value" are two separate `\w+` matches).
+                        const kvRange = document.getWordRangeAtPosition(position, /\w+=(?:"[^"]*"|'[^']*'|\w+)/)
+
+                        if (kvRange) {
+                            return ohHoverProvider.getHover(document.getText(kvRange), hoveredLine)
+                        }
+
+                        // Fall back to matching a plain identifier. Restricting word detection to
+                        // identifier characters ensures that hovering right next to a following
+                        // character like `{`, `[` or `(` (with no whitespace in between) still resolves
+                        // to just the item name instead of an undefined range (which would otherwise
+                        // make VS Code fall back to the entire document's text).
+                        const hoveredRange = document.getWordRangeAtPosition(position, /[A-Za-z0-9_]+/)
+
+                        if (!hoveredRange) {
+                            return null
+                        }
+
                         const hoveredText = document.getText(hoveredRange)
 
                         // let matchresult = hoveredText.match(/(\w+){1}/gm)

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -241,13 +241,21 @@ async function init(disposables: vscode.Disposable[], context: vscode.ExtensionC
 
         disposables.push(
             vscode.languages.registerHoverProvider(
-                { language: 'openhab', scheme: 'file' },
+                [
+                    { language: 'openhab', scheme: 'file' },
+                    { language: 'javascript', scheme: 'file' },
+                    { pattern: '**/*.sitemap', scheme: 'file' },
+                ],
                 {
                     provideHover(document, position, token) {
                         const docLine = document.lineAt(position.line)
                         const hoveredLine = docLine.text.slice(docLine.firstNonWhitespaceCharacterIndex)
 
-                        const hoveredRange = document.getWordRangeAtPosition(position)
+                        // Try to match a key="value" / key=value pair first (e.g. item=FF_Bath_Light in
+                        // sitemap files), then fall back to matching a plain word.
+                        const hoveredRange =
+                            document.getWordRangeAtPosition(position, /\w+=(?:"[^"]*"|'[^']*'|\S+)/) ||
+                            document.getWordRangeAtPosition(position)
                         const hoveredText = document.getText(hoveredRange)
 
                         // let matchresult = hoveredText.match(/(\w+){1}/gm)

--- a/meta/openhab.tmLanguage.json
+++ b/meta/openhab.tmLanguage.json
@@ -360,11 +360,11 @@
                     "name": "variable.language.openhab"
                 },
                 {
-                    "match": "\\b(Color|Contact|DateTime|Dimmer|Group|Number|Player|Rollershutter|String|Switch|Location)\\b",
+                    "match": "\\b(Color|Contact|DateTime|Dimmer|Group|Number:[a-zA-Z]*|Number|Player|Rollershutter|String|Switch|Location)\\b",
                     "name": "variable.language.openhab"
                 },
                 {
-                    "match": "\\b(Frame|Default|Text|Group|Switch|Selection|Setpoint|Slider|Colorpicker|Chart|Webview|Image|Video)\\b",
+                    "match": "\\b(Frame|Default|Text|Group|Switch|Buttongrid|Button|Selection|Setpoint|Slider|Colorpicker|Colortemperaturepicker|Input|Chart|Webview|Mapview|Image|Video)\\b",
                     "name": "variable.language.openhab"
                 },
                 {

--- a/serverJS/package-lock.json
+++ b/serverJS/package-lock.json
@@ -11,7 +11,8 @@
             "dependencies": {
                 "eventsource": "^2.0.2",
                 "lodash": "^4.18.1",
-                "vscode-languageserver": "^7.0.0"
+                "vscode-languageserver": "^7.0.0",
+                "vscode-languageserver-textdocument": "^1.0.12"
             },
             "devDependencies": {
                 "jest": "^29.3.1",
@@ -6664,6 +6665,12 @@
                 "vscode-jsonrpc": "6.0.0",
                 "vscode-languageserver-types": "3.16.0"
             }
+        },
+        "node_modules/vscode-languageserver-textdocument": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+            "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+            "license": "MIT"
         },
         "node_modules/vscode-languageserver-types": {
             "version": "3.16.0",

--- a/serverJS/package.json
+++ b/serverJS/package.json
@@ -13,7 +13,8 @@
     "dependencies": {
         "eventsource": "^2.0.2",
         "lodash": "^4.18.1",
-        "vscode-languageserver": "^7.0.0"
+        "vscode-languageserver": "^7.0.0",
+        "vscode-languageserver-textdocument": "^1.0.12"
     },
     "devDependencies": {
         "jest": "^29.3.1",

--- a/serverJS/src/Server.js
+++ b/serverJS/src/Server.js
@@ -6,6 +6,7 @@ const {
     ProposedFeatures,
     DidChangeConfigurationNotification,
 } = require('vscode-languageserver')
+const { TextDocument } = require('vscode-languageserver-textdocument')
 
 const { validateTextDocument } = require('./DocumentValidation/DocumentValidator')
 
@@ -26,7 +27,7 @@ class Server {
         this.connection.onDidChangeConfiguration(this.configurationChanged.bind(this))
 
         // documents handler
-        this.documents = new TextDocuments()
+        this.documents = new TextDocuments(TextDocument)
 
         // add handlers to documents
         this.documents.onDidOpen(this.documentOpened.bind(this))

--- a/serverJS/src/Server.js
+++ b/serverJS/src/Server.js
@@ -71,8 +71,24 @@ class Server {
     async initializeItemCompletionProvider() {
         this.itemsCompletionProvider = new ItemCompletionProvider()
         // TODO what todo here if it fails?
-        const err = await this.itemsCompletionProvider.start(this.globalSettings.host, this.globalSettings.port)
+        const { host, port } = this.getHostAndPort()
+        const err = await this.itemsCompletionProvider.start(host, port)
         return err
+    }
+
+    /**
+     * Resolves the configured openHAB host/port, preferring the current
+     * `openhab.connection.host`/`openhab.connection.port` settings and
+     * falling back to the deprecated flat `openhab.host`/`openhab.port`
+     * settings for backwards compatibility.
+     */
+    getHostAndPort() {
+        const settings = this.globalSettings || {}
+        const connection = settings.connection || {}
+        return {
+            host: connection.host || settings.host,
+            port: connection.port || settings.port,
+        }
     }
 
     exit() {
@@ -89,7 +105,8 @@ class Server {
         }
         this.globalSettings = change.settings.openhab
         if (this.itemsCompletionProvider) {
-            this.itemsCompletionProvider.restartIfConfigChanged(this.globalSettings.host, this.globalSettings.port)
+            const { host, port } = this.getHostAndPort()
+            this.itemsCompletionProvider.restartIfConfigChanged(host, port)
         }
         // Revalidate all open text documents - not needed right now but might make sense based on settings for validation
         // this.documents.all().forEach(this.validateDocument)

--- a/snippets/openhab.json
+++ b/snippets/openhab.json
@@ -15,7 +15,7 @@
     },
     "item-in-sitemap": {
         "prefix": "item-in-sitemap",
-        "body": "${1|Chart,Colorpicker,Default,Frame,Group,Image,Mapview,Selection,Setpoint,Slider,Switch,Text,Video,Webview|} item=${2:Item_ID} label=\"${3:Item Label}\" icon=\"${3:icon}\"",
+        "body": "${1|Buttongrid,Button,Chart,Colorpicker,Colortemperaturepicker,Default,Frame,Group,Image,Input,Mapview,Selection,Setpoint,Slider,Switch,Text,Video,Webview|} item=${2:Item_ID} label=\"${3:Item Label}\" icon=\"${3:icon}\"",
         "description": "Generic openHAB Item snippet to put in *.sitemap"
     }
 }


### PR DESCRIPTION
## Summary

Split out from #329 per @florian-h05's request in https://github.com/openhab/openhab-vscode/pull/329#issuecomment-5071145393 to separate the other hover/editor improvements from the log-parsing functionality (see the companion PR for the log-based state extraction).

### Added

- Hover tooltips (state lookups from the REST API) now work in `.js` automation files, not just `.items` and `.rules` files.
- Hover tooltips work in `.sitemap` files, including `item=<name>` references on widget lines (e.g. `Switch item=FF_Bath_Light`).
- Syntax highlighting and snippet updates for additional sitemap widget types (`Buttongrid`, `Button`, `Colortemperaturepicker`, `Input`, `Mapview`) and dimensioned `Number:` item types, following up on #328.

### Notes for reviewers

- Ready for review, split out of #329 to isolate it from the log-parsing changes requested to be reviewed separately.