### PR TITLE
fix: hover word detection failed when item name directly touched a bracket

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -247,7 +247,17 @@ async function init(disposables: vscode.Disposable[], context: vscode.ExtensionC
                         const docLine = document.lineAt(position.line)
                         const hoveredLine = docLine.text.slice(docLine.firstNonWhitespaceCharacterIndex)
 
-                        const hoveredRange = document.getWordRangeAtPosition(position)
+                        // Explicitly restrict word detection to identifier characters, so that
+                        // hovering right next to a following character like `{`, `[` or `(`
+                        // (with no whitespace in between) still resolves to just the item name
+                        // instead of an undefined range (which would otherwise make VS Code
+                        // fall back to the entire document's text).
+                        const hoveredRange = document.getWordRangeAtPosition(position, /[A-Za-z0-9_]+/)
+
+                        if (!hoveredRange) {
+                            return null
+                        }
+
                         const hoveredText = document.getText(hoveredRange)
 
                         // let matchresult = hoveredText.match(/(\w+){1}/gm)


### PR DESCRIPTION
Fixes a hover bug where an item name immediately followed by a non-identifier character (e.g. \itemName{\ with no space) would not be recognized, while \itemName {\ (with a space) worked fine.

Root cause: \document.getWordRangeAtPosition(position)\ was called without an explicit word regex, relying on VS Code's default word separators. When the hover position landed exactly on the boundary between the identifier and the following character, \getWordRangeAtPosition\ could return \undefined\. \document.getText(undefined)\ then falls back to returning the **entire document's text**, which fails the single-word check further down and silently skips the hover.

Fix: pass an explicit identifier regex (\/[A-Za-z0-9_]+/\) to \getWordRangeAtPosition\, and return \
ull\ immediately if no range is found instead of falling through to \document.getText(undefined)\.

Tested with \
pm test\ (client) - 30/30 passing, and \	sc --noEmit\ clean.